### PR TITLE
CI: Enable for main branch and PRs + update actions

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -24,13 +24,13 @@ jobs:
         run: ./gradlew assembleDebug
 
       - name: Upload APK
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: HeliBoard-debug
           path: app/build/outputs/apk/debug/*-debug*.apk
 
       - name: Archive reports for failed job
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: reports
           path: '*/build/reports'

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,10 +1,6 @@
 name: Build
 
-on:
-  push:
-    branches: [ new ]
-  pull_request:
-    branches: [ new ]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,6 +1,9 @@
 name: Build
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -18,7 +18,8 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: gradle
+
+      - uses: gradle/actions/setup-gradle@v3
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew


### PR DESCRIPTION
I don't really see a reason why CI should only run for a single branch (that currently does not even exist), so let's enable it for all branches and pull requests.

Plus some routine action updates.

Test run: https://github.com/Croydon/android-HeliBoard/actions/runs/7908391276