### PR TITLE
Get default long press delay value from Android settings

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
@@ -98,7 +98,6 @@ object Defaults {
     const val PREF_GESTURE_INPUT = true
     const val PREF_VIBRATION_DURATION_SETTINGS = -1
     const val PREF_KEYPRESS_SOUND_VOLUME = -0.01f
-    const val PREF_KEY_LONGPRESS_TIMEOUT = 300
     const val PREF_ENABLE_EMOJI_ALT_PHYSICAL_KEY = true
     const val PREF_GESTURE_PREVIEW_TRAIL = true
     const val PREF_GESTURE_FLOATING_PREVIEW_TEXT = true

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -17,6 +17,7 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.view.ContextThemeWrapper;
 import android.view.inputmethod.EditorInfo;
+import android.view.ViewConfiguration;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -314,6 +315,11 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
 
     public static void writePrefAdditionalSubtypes(final SharedPreferences prefs, final String prefSubtypes) {
         prefs.edit().putString(PREF_ADDITIONAL_SUBTYPES, prefSubtypes).apply();
+    }
+
+    public static int readDefaultKeyLongpressTimeout() {
+        final int default_longpress_key_timeout = ViewConfiguration.getLongPressTimeout();
+        return default_longpress_key_timeout;
     }
 
     public static int readHorizontalSpaceSwipe(final SharedPreferences prefs) {

--- a/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
@@ -206,7 +206,7 @@ public class SettingsValues {
         mScreenMetrics = Settings.readScreenMetrics(res);
 
         // Compute other readable settings
-        mKeyLongpressTimeout = prefs.getInt(Settings.PREF_KEY_LONGPRESS_TIMEOUT, Defaults.PREF_KEY_LONGPRESS_TIMEOUT);
+        mKeyLongpressTimeout = prefs.getInt(Settings.PREF_KEY_LONGPRESS_TIMEOUT, Settings.readDefaultKeyLongpressTimeout());
         mKeypressVibrationDuration = prefs.getInt(Settings.PREF_VIBRATION_DURATION_SETTINGS, Defaults.PREF_VIBRATION_DURATION_SETTINGS);
         mKeypressSoundVolume = prefs.getFloat(Settings.PREF_KEYPRESS_SOUND_VOLUME, Defaults.PREF_KEYPRESS_SOUND_VOLUME);
         mEnableEmojiAltPhysicalKey = prefs.getBoolean(Settings.PREF_ENABLE_EMOJI_ALT_PHYSICAL_KEY, Defaults.PREF_ENABLE_EMOJI_ALT_PHYSICAL_KEY);

--- a/app/src/main/java/helium314/keyboard/settings/screens/AdvancedScreen.kt
+++ b/app/src/main/java/helium314/keyboard/settings/screens/AdvancedScreen.kt
@@ -96,8 +96,8 @@ fun createAdvancedSettings(context: Context) = listOf(
         SliderPreference(
             name = setting.title,
             key = setting.key,
-            default = Defaults.PREF_KEY_LONGPRESS_TIMEOUT,
-            range = 100f..700f,
+            default = Settings.readDefaultKeyLongpressTimeout(),
+            range = 100f..1500f,
             description = { stringResource(R.string.abbreviation_unit_milliseconds, it.toString()) }
         )
     },


### PR DESCRIPTION
The default long press delay value is set within Android's Settings --> Accessibility --> Touch & hold delay, so use that as the default value in Heliboard as well.  Also, increase the max long press delay value to 1500 so that it matches the max value in Android's settings.

<!--
* Please describe briefly what your pull request proposes to fix or improve.
* If it's not completely obvious, describe what the PR does to achieve the desired result.
* If you use someone else's code, please mention or better link to the source.
* See the contributing section in the readme for more detailed guideline: https://github.com/Helium314/HeliBoard?tab=readme-ov-file#guidelines
-->
