### PR TITLE
Enable abort on lint check failure

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,7 +53,7 @@ android {
     }
 
     lintOptions {
-        abortOnError false
+        abortOnError true
     }
 
     ndkVersion '26.2.11394342'


### PR DESCRIPTION
If lint shows an error that can not be fixed then it is better to disable a specific lint check than disable the entire thing.

<!--
* Please describe briefly what your pull request proposes to fix or improve.
* If it's not completely obvious, describe what the PR does to achieve the desired result.
* If you use someone else's code, please mention or better link to the source.
* See the contributing section in the readme for more detailed guideline: https://github.com/Helium314/HeliBoard?tab=readme-ov-file#guidelines
-->
