### PR TITLE
Fix toolbar keys order in RTL layout

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,7 +53,7 @@ android {
     }
 
     lintOptions {
-        abortOnError false
+        abortOnError true
     }
 
     ndkVersion '26.2.11394342'

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -94,7 +94,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_BLOCK_POTENTIALLY_OFFENSIVE = "block_potentially_offensive";
     public static final String PREF_LANGUAGE_SWITCH_KEY = "language_switch_key";
     public static final String PREF_SHOW_EMOJI_KEY = "show_emoji_key";
-    public static final String PREF_FIX_TOOLBAR_DIRECTION = "fix_toolbar_direction";
+    public static final String PREF_VARIABLE_TOOLBAR_DIRECTION = "var_toolbar_direction";
     public static final String PREF_ADDITIONAL_SUBTYPES = "additional_subtypes";
     public static final String PREF_ENABLE_SPLIT_KEYBOARD = "split_keyboard";
     public static final String PREF_SPLIT_SPACER_SCALE = "split_spacer_scale";

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -94,6 +94,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_BLOCK_POTENTIALLY_OFFENSIVE = "block_potentially_offensive";
     public static final String PREF_LANGUAGE_SWITCH_KEY = "language_switch_key";
     public static final String PREF_SHOW_EMOJI_KEY = "show_emoji_key";
+    public static final String PREF_FIX_TOOLBAR_DIRECTION = "fix_toolbar_direction";
     public static final String PREF_ADDITIONAL_SUBTYPES = "additional_subtypes";
     public static final String PREF_ENABLE_SPLIT_KEYBOARD = "split_keyboard";
     public static final String PREF_SPLIT_SPACER_SCALE = "split_spacer_scale";

--- a/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
@@ -68,7 +68,7 @@ public class SettingsValues {
     public final boolean mShowsPopupHints;
     public final boolean mSpaceForLangChange;
     public final boolean mShowsEmojiKey;
-    public final boolean mFixToolbarDirection;
+    public final boolean mVarToolbarDirection;
     public final boolean mUsePersonalizedDicts;
     public final boolean mUseDoubleSpacePeriod;
     public final boolean mBlockPotentiallyOffensive;
@@ -151,7 +151,7 @@ public class SettingsValues {
         mShowsPopupHints = prefs.getBoolean(Settings.PREF_SHOW_POPUP_HINTS, false);
         mSpaceForLangChange = prefs.getBoolean(Settings.PREF_SPACE_TO_CHANGE_LANG, true);
         mShowsEmojiKey = prefs.getBoolean(Settings.PREF_SHOW_EMOJI_KEY, false);
-        mFixToolbarDirection = prefs.getBoolean(Settings.PREF_FIX_TOOLBAR_DIRECTION, true);
+        mVarToolbarDirection = prefs.getBoolean(Settings.PREF_VARIABLE_TOOLBAR_DIRECTION, true);
         mUsePersonalizedDicts = prefs.getBoolean(Settings.PREF_KEY_USE_PERSONALIZED_DICTS, true);
         mUseDoubleSpacePeriod = prefs.getBoolean(Settings.PREF_KEY_USE_DOUBLE_SPACE_PERIOD, true)
                 && inputAttributes.mIsGeneralTextInput;

--- a/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
@@ -68,6 +68,7 @@ public class SettingsValues {
     public final boolean mShowsPopupHints;
     public final boolean mSpaceForLangChange;
     public final boolean mShowsEmojiKey;
+    public final boolean mFixToolbarDirection;
     public final boolean mUsePersonalizedDicts;
     public final boolean mUseDoubleSpacePeriod;
     public final boolean mBlockPotentiallyOffensive;
@@ -150,6 +151,7 @@ public class SettingsValues {
         mShowsPopupHints = prefs.getBoolean(Settings.PREF_SHOW_POPUP_HINTS, false);
         mSpaceForLangChange = prefs.getBoolean(Settings.PREF_SPACE_TO_CHANGE_LANG, true);
         mShowsEmojiKey = prefs.getBoolean(Settings.PREF_SHOW_EMOJI_KEY, false);
+        mFixToolbarDirection = prefs.getBoolean(Settings.PREF_FIX_TOOLBAR_DIRECTION, true);
         mUsePersonalizedDicts = prefs.getBoolean(Settings.PREF_KEY_USE_PERSONALIZED_DICTS, true);
         mUseDoubleSpacePeriod = prefs.getBoolean(Settings.PREF_KEY_USE_DOUBLE_SPACE_PERIOD, true)
                 && inputAttributes.mIsGeneralTextInput;

--- a/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.java
+++ b/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.java
@@ -264,7 +264,7 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
 
     public void setRtl(final boolean isRtlLanguage) {
         final int layoutDirection;
-        if (Settings.getInstance().getCurrent().mFixToolbarDirection)
+        if (!Settings.getInstance().getCurrent().mVarToolbarDirection)
             layoutDirection = ViewCompat.LAYOUT_DIRECTION_LOCALE;
         else{
             layoutDirection = isRtlLanguage ? ViewCompat.LAYOUT_DIRECTION_RTL : ViewCompat.LAYOUT_DIRECTION_LTR;

--- a/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.java
+++ b/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.java
@@ -128,7 +128,7 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
         public void setLayoutDirection(final boolean isRtlLanguage) {
             final int layoutDirection = isRtlLanguage ? ViewCompat.LAYOUT_DIRECTION_RTL
                     : ViewCompat.LAYOUT_DIRECTION_LTR;
-            ViewCompat.setLayoutDirection(mSuggestionStripView, ViewCompat.LAYOUT_DIRECTION_LTR);
+            ViewCompat.setLayoutDirection(mSuggestionStripView, ViewCompat.LAYOUT_DIRECTION_LOCALE);
             ViewCompat.setLayoutDirection(mSuggestionsStrip, layoutDirection);
         }
 

--- a/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.java
+++ b/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.java
@@ -109,6 +109,7 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
     Listener mListener;
     private SuggestedWords mSuggestedWords = SuggestedWords.getEmptyInstance();
     private int mStartIndexOfMoreSuggestions;
+    private int mRtl = 1; // 1 if LTR, -1 if RTL
 
     private final SuggestionStripLayoutHelper mLayoutHelper;
     private final StripVisibilityGroup mStripVisibilityGroup;
@@ -125,10 +126,8 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
             showSuggestionsStrip();
         }
 
-        public void setLayoutDirection(final boolean isRtlLanguage) {
-            final int layoutDirection = isRtlLanguage ? ViewCompat.LAYOUT_DIRECTION_RTL
-                    : ViewCompat.LAYOUT_DIRECTION_LTR;
-            ViewCompat.setLayoutDirection(mSuggestionStripView, ViewCompat.LAYOUT_DIRECTION_LOCALE);
+        public void setLayoutDirection(final int layoutDirection) {
+            ViewCompat.setLayoutDirection(mSuggestionStripView, layoutDirection);
             ViewCompat.setLayoutDirection(mSuggestionsStrip, layoutDirection);
         }
 
@@ -251,7 +250,7 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
         if (pinnedVoiceKey != null)
             pinnedVoiceKey.setVisibility(currentSettingsValues.mShowsVoiceInputKey ? VISIBLE : GONE);
         mToolbarExpandKey.setImageDrawable(currentSettingsValues.mIncognitoModeEnabled ? mIncognitoIcon : mToolbarArrowIcon);
-        mToolbarExpandKey.setScaleX(mToolbarContainer.getVisibility() != VISIBLE ? 1f : -1f);
+        mToolbarExpandKey.setScaleX((mToolbarContainer.getVisibility() != VISIBLE ? 1f : -1f) * mRtl);
 
         // hide pinned keys if device is locked, and avoid expanding toolbar
         final KeyguardManager km = (KeyguardManager) getContext().getSystemService(Context.KEYGUARD_SERVICE);
@@ -264,7 +263,14 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
     }
 
     public void setRtl(final boolean isRtlLanguage) {
-        mStripVisibilityGroup.setLayoutDirection(isRtlLanguage);
+        final int layoutDirection;
+        if (Settings.getInstance().getCurrent().mFixToolbarDirection)
+            layoutDirection = ViewCompat.LAYOUT_DIRECTION_LOCALE;
+        else{
+            layoutDirection = isRtlLanguage ? ViewCompat.LAYOUT_DIRECTION_RTL : ViewCompat.LAYOUT_DIRECTION_LTR;
+            mRtl = isRtlLanguage ? -1 : 1;
+        }
+        mStripVisibilityGroup.setLayoutDirection(layoutDirection);
     }
 
     public void setSuggestions(final SuggestedWords suggestedWords, final boolean isRtlLanguage) {
@@ -699,7 +705,7 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
             mSuggestionsStrip.setVisibility(VISIBLE);
             mPinnedKeys.setVisibility(VISIBLE);
         }
-        mToolbarExpandKey.setScaleX(visible ? -1f : 1f);
+        mToolbarExpandKey.setScaleX((visible ? -1f : 1f) * mRtl);
     }
 
     private void addKeyToPinnedKeys(final ToolbarKey pinnedKey) {

--- a/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.java
+++ b/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.java
@@ -252,7 +252,7 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
         if (pinnedVoiceKey != null)
             pinnedVoiceKey.setVisibility(currentSettingsValues.mShowsVoiceInputKey ? VISIBLE : GONE);
         mToolbarExpandKey.setImageDrawable(currentSettingsValues.mIncognitoModeEnabled ? mIncognitoIcon : mToolbarArrowIcon);
-        mToolbarExpandKey.setScaleX((mToolbarContainer.getVisibility() != VISIBLE ? 1f : -1f) * mRtl);
+        mToolbarExpandKey.setScaleX(mToolbarContainer.getVisibility() != VISIBLE ? 1f : -1f);
 
         // hide pinned keys if device is locked, and avoid expanding toolbar
         final KeyguardManager km = (KeyguardManager) getContext().getSystemService(Context.KEYGUARD_SERVICE);

--- a/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.java
+++ b/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.java
@@ -701,7 +701,7 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
             mSuggestionsStrip.setVisibility(VISIBLE);
             mPinnedKeys.setVisibility(VISIBLE);
         }
-        mToolbarExpandKey.setScaleX((visible ? -1f : 1f) * mRtl);
+        mToolbarExpandKey.setScaleX(visible ? -1f : 1f);
     }
 
     private void addKeyToPinnedKeys(final ToolbarKey pinnedKey) {

--- a/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.java
+++ b/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.java
@@ -129,7 +129,7 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
         public void setLayoutDirection(final boolean isRtlLanguage) {
             final int layoutDirection = isRtlLanguage ? ViewCompat.LAYOUT_DIRECTION_RTL
                     : ViewCompat.LAYOUT_DIRECTION_LTR;
-            ViewCompat.setLayoutDirection(mSuggestionStripView, layoutDirection);
+            ViewCompat.setLayoutDirection(mSuggestionStripView, ViewCompat.LAYOUT_DIRECTION_LTR);
             ViewCompat.setLayoutDirection(mSuggestionsStrip, layoutDirection);
         }
 

--- a/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.java
+++ b/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.java
@@ -109,7 +109,6 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
     Listener mListener;
     private SuggestedWords mSuggestedWords = SuggestedWords.getEmptyInstance();
     private int mStartIndexOfMoreSuggestions;
-    private int mRtl = 1; // 1 if LTR, -1 if RTL
 
     private final SuggestionStripLayoutHelper mLayoutHelper;
     private final StripVisibilityGroup mStripVisibilityGroup;
@@ -266,7 +265,6 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
 
     public void setRtl(final boolean isRtlLanguage) {
         mStripVisibilityGroup.setLayoutDirection(isRtlLanguage);
-        mRtl = isRtlLanguage ? -1 : 1;
     }
 
     public void setSuggestions(final SuggestedWords suggestedWords, final boolean isRtlLanguage) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -776,8 +776,8 @@ New dictionary:
     <string name="action_none">None</string>
     <!-- Option to move the cursor when swiping the spacebar -->
     <string name="space_swipe_move_cursor_entry">Move Cursor</string>
-    <!-- Title of the settings to fix toolbar direction -->
-    <string name="fix_toolbar_direction">Fix toolbar direction</string>
-    <!-- Description of the fix_toolbar_direction setting -->
-    <string name="fix_toolbar_direction_summary">If disabled, the direction of the active layout will be used</string>
+    <!-- Title of the settings for variable toolbar direction -->
+    <string name="var_toolbar_direction">Variable toolbar direction</string>
+    <!-- Description of the variable toolbar direction setting -->
+    <string name="var_toolbar_direction_summary">Reverse direction when a right-to-left keyboard subtype is selected</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -778,4 +778,6 @@ New dictionary:
     <string name="space_swipe_move_cursor_entry">Move Cursor</string>
     <!-- Title of the settings to fix toolbar direction -->
     <string name="fix_toolbar_direction">Fix toolbar direction</string>
+    <!-- Description of the fix_toolbar_direction setting -->
+    <string name="fix_toolbar_direction_summary">If disabled, the direction of the active layout will be used</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -776,4 +776,6 @@ New dictionary:
     <string name="action_none">None</string>
     <!-- Option to move the cursor when swiping the spacebar -->
     <string name="space_swipe_move_cursor_entry">Move Cursor</string>
+    <!-- Title of the settings to fix toolbar direction -->
+    <string name="fix_toolbar_direction">Fix toolbar direction</string>
 </resources>

--- a/app/src/main/res/xml/prefs_screen_preferences.xml
+++ b/app/src/main/res/xml/prefs_screen_preferences.xml
@@ -101,6 +101,7 @@
         <SwitchPreference
             android:key="fix_toolbar_direction"
             android:title="@string/fix_toolbar_direction"
+            android:summary="@string/fix_toolbar_direction_summary"
             android:defaultValue="true"
             android:persistent="true" />
 

--- a/app/src/main/res/xml/prefs_screen_preferences.xml
+++ b/app/src/main/res/xml/prefs_screen_preferences.xml
@@ -98,6 +98,12 @@
             android:key="toolbar_keys"
             android:title="@string/toolbar_keys" />
 
+        <SwitchPreference
+            android:key="fix_toolbar_direction"
+            android:title="@string/fix_toolbar_direction"
+            android:defaultValue="true"
+            android:persistent="true" />
+
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/settings_category_clipboard_history">

--- a/app/src/main/res/xml/prefs_screen_preferences.xml
+++ b/app/src/main/res/xml/prefs_screen_preferences.xml
@@ -99,9 +99,9 @@
             android:title="@string/toolbar_keys" />
 
         <SwitchPreference
-            android:key="fix_toolbar_direction"
-            android:title="@string/fix_toolbar_direction"
-            android:summary="@string/fix_toolbar_direction_summary"
+            android:key="var_toolbar_direction"
+            android:title="@string/var_toolbar_direction"
+            android:summary="@string/var_toolbar_direction_summary"
             android:defaultValue="true"
             android:persistent="true" />
 


### PR DESCRIPTION
Fix the toolbar keys direction so that it does not change when switching between an RTL/LTR layouts.
The issue was described here: https://github.com/Helium314/HeliBoard/issues/557
Upon testing the app in Android Studio, the order seems to be fixed with no adverse effect on the direction of the text in the auto-complete (RTL layout) suggestions.