### PR TITLE
Fix auto correct & select all icons

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/utils/ToolbarUtils.kt
+++ b/app/src/main/java/helium314/keyboard/latin/utils/ToolbarUtils.kt
@@ -69,7 +69,7 @@ private fun getStyleableIconId(key: ToolbarKey) = when (key) {
     UNDO -> R.styleable.Keyboard_iconUndo
     REDO -> R.styleable.Keyboard_iconRedo
     INCOGNITO -> R.styleable.Keyboard_iconIncognitoKey
-    AUTOCORRECT -> R.styleable.Keyboard_iconLanguageSwitchKey
+    AUTOCORRECT -> R.styleable.Keyboard_iconAutoCorrect
     CLEAR_CLIPBOARD -> R.styleable.Keyboard_iconClearClipboardKey
     FULL_LEFT -> R.styleable.Keyboard_iconFullLeft
     FULL_RIGHT -> R.styleable.Keyboard_iconFullRight

--- a/app/src/main/res/drawable/ic_autocorrect.xml
+++ b/app/src/main/res/drawable/ic_autocorrect.xml
@@ -1,0 +1,12 @@
+<!--
+    icon available in Android Studio
+    SPDX-License-Identifier: Apache-2.0
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24" >
+    <path android:fillColor="#FFF"
+        android:pathData="M5,17v2h14v-2L5,17zM9.5,12.8h5l0.9,2.2h2.1L12.75,4h-1.5L6.5,15h2.1l0.9,-2.2zM12,5.98L13.87,11h-3.74L12,5.98z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_autocorrect_rounded.xml
+++ b/app/src/main/res/drawable/ic_autocorrect_rounded.xml
@@ -1,0 +1,12 @@
+<!--
+    icon available in Android Studio
+    SPDX-License-Identifier: Apache-2.0
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path android:fillColor="#FFF"
+        android:pathData="M200,760v-80h560v80L200,760ZM276,600 L440,160h80l164,440h-76l-38,-112L392,488l-40,112h-76ZM414,424h132l-64,-182h-4l-64,182Z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_select_all.xml
+++ b/app/src/main/res/drawable/ic_select_all.xml
@@ -8,5 +8,5 @@
     android:viewportHeight="24"
     android:viewportWidth="24" >
     <path android:fillColor="#FFF"
-        android:pathData="M2,20h20v4H2V20zM5.49,17h2.42l1.27,-3.58h5.65L16.09,17h2.42L13.25,3h-2.5L5.49,17zM9.91,11.39l2.03,-5.79h0.12l2.03,5.79H9.91z"/>
+        android:pathData="M3,5h2L5,3c-1.1,0 -2,0.9 -2,2zM3,13h2v-2L3,11v2zM7,21h2v-2L7,19v2zM3,9h2L5,7L3,7v2zM13,3h-2v2h2L13,3zM19,3v2h2c0,-1.1 -0.9,-2 -2,-2zM5,21v-2L3,19c0,1.1 0.9,2 2,2zM3,17h2v-2L3,15v2zM9,3L7,3v2h2L9,3zM11,21h2v-2h-2v2zM19,13h2v-2h-2v2zM19,21c1.1,0 2,-0.9 2,-2h-2v2zM19,9h2L21,7h-2v2zM19,17h2v-2h-2v2zM15,21h2v-2h-2v2zM15,5h2L17,3h-2v2zM7,17h10L17,7L7,7v10zM9,9h6v6L9,15L9,9z"/>
 </vector>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -251,6 +251,7 @@
         <attr name="iconShiftKeyShifted" format="reference" />
         <attr name="iconShortcutKeyDisabled" format="reference" />
         <attr name="iconLanguageSwitchKey" format="reference" />
+        <attr name="iconAutoCorrect" format="reference" />
         <attr name="iconZwnjKey" format="reference" />
         <attr name="iconZwjKey" format="reference" />
         <attr name="iconImeKey" format="reference" />

--- a/app/src/main/res/values/keyboard-icons-holo.xml
+++ b/app/src/main/res/values/keyboard-icons-holo.xml
@@ -21,6 +21,7 @@
         <item name="iconShiftKeyShifted">@drawable/sym_keyboard_shift_locked_holo</item>
         <item name="iconShortcutKeyDisabled">@drawable/sym_keyboard_voice_off_holo</item>
         <item name="iconLanguageSwitchKey">@drawable/sym_keyboard_language_switch</item>
+        <item name="iconAutoCorrect">@drawable/ic_autocorrect</item>
         <item name="iconZwnjKey">@drawable/sym_keyboard_zwnj_holo</item>
         <item name="iconZwjKey">@drawable/sym_keyboard_zwj_holo</item>
         <item name="iconEmojiActionKey">@drawable/sym_keyboard_smiley_holo</item>

--- a/app/src/main/res/values/keyboard-icons-lxx-light.xml
+++ b/app/src/main/res/values/keyboard-icons-lxx-light.xml
@@ -26,6 +26,7 @@
         <item name="iconIncognitoKey">@drawable/sym_keyboard_incognito_lxx</item>
         <item name="iconSpaceKeyForNumberLayout">@drawable/sym_keyboard_space_lxx</item>
         <item name="iconLanguageSwitchKey">@drawable/sym_keyboard_language_switch_lxx</item>
+        <item name="iconAutoCorrect">@drawable/ic_autocorrect</item>
         <item name="iconZwnjKey">@drawable/sym_keyboard_zwnj_lxx</item>
         <item name="iconZwjKey">@drawable/sym_keyboard_zwj_lxx</item>
         <item name="iconEmojiActionKey">@drawable/sym_keyboard_smiley_lxx</item>

--- a/app/src/main/res/values/keyboard-icons-rounded.xml
+++ b/app/src/main/res/values/keyboard-icons-rounded.xml
@@ -25,6 +25,7 @@
         <item name="iconIncognitoKey">@drawable/sym_keyboard_incognito_lxx</item>
         <item name="iconSpaceKeyForNumberLayout">@drawable/sym_keyboard_space_rounded</item>
         <item name="iconLanguageSwitchKey">@drawable/sym_keyboard_language_switch_lxx</item>
+        <item name="iconAutoCorrect">@drawable/ic_autocorrect_rounded</item>
         <item name="iconZwnjKey">@drawable/sym_keyboard_zwnj_lxx</item>
         <item name="iconZwjKey">@drawable/sym_keyboard_zwj_lxx</item>
         <item name="iconEmojiActionKey">@drawable/sym_keyboard_smiley_rounded</item>


### PR DESCRIPTION
Select all icon:
![select_all](https://github.com/Helium314/HeliBoard/assets/151087174/f67e5869-0f2c-4460-87ac-8254863549ff)
Select word icon:
![select_word](https://github.com/Helium314/HeliBoard/assets/151087174/6e831c4d-2342-463f-b25c-b49a9406cffe)
Autocorrect icon:
![autocorrect](https://github.com/Helium314/HeliBoard/assets/151087174/86b269a8-f875-4cd2-ad2a-abdb119e32fd)
For some reason currently "Select all" has the icon A like the one above which is counterintuitive and should be used for autocorrect key that now has the obscure language switch symbol.
See issue #524