### PR TITLE
Get suggestions in URI fields

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/InputAttributes.java
+++ b/app/src/main/java/helium314/keyboard/latin/InputAttributes.java
@@ -85,6 +85,7 @@ public final class InputAttributes {
 
         // inputClass == InputType.TYPE_CLASS_TEXT
         final int variation = inputType & InputType.TYPE_MASK_VARIATION;
+        final boolean uriVariation = 0 != (variation & InputType.TYPE_TEXT_VARIATION_URI);
         final boolean flagNoSuggestions = 0 != (inputType & InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS);
         final boolean flagMultiLine = 0 != (inputType & InputType.TYPE_TEXT_FLAG_MULTI_LINE);
         final boolean flagAutoCorrect = 0 != (inputType & InputType.TYPE_TEXT_FLAG_AUTO_CORRECT);
@@ -92,7 +93,7 @@ public final class InputAttributes {
 
         // TODO: Have a helper method in InputTypeUtils
         // Make sure that passwords are not displayed in {@link SuggestionStripView}.
-        mShouldShowSuggestions = !mIsPasswordField && !flagNoSuggestions;
+        mShouldShowSuggestions = !mIsPasswordField && !flagNoSuggestions || uriVariation;
         mMayOverrideShowingSuggestions = !mIsPasswordField;
 
         mShouldInsertSpacesAutomatically = InputTypeUtils.isAutoSpaceFriendlyType(inputType);

--- a/app/src/main/java/helium314/keyboard/latin/common/Constants.java
+++ b/app/src/main/java/helium314/keyboard/latin/common/Constants.java
@@ -140,6 +140,10 @@ public final class Constants {
     // right for this.
     public static final int MAX_CHARACTERS_FOR_RECAPITALIZATION = 1024 * 100;
 
+    // How many characters can a composed word have before it is assumed to be non-suggestible.
+    // The length of the lengthy word "internationalization" is 20.
+    public static final int MAX_CHARACTERS_FOR_SUGGESTIONS = 20;
+
     // Key events coming any faster than this are long-presses.
     public static final int LONG_PRESS_MILLISECONDS = 200;
     // TODO: Set this value appropriately.

--- a/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
@@ -1580,7 +1580,8 @@ public final class InputLogic {
             return;
         }
 
-        if (!mWordComposer.isComposingWord() && !settingsValues.mBigramPredictionEnabled) {
+        if (!mWordComposer.isComposingWord() && !settingsValues.mBigramPredictionEnabled
+                || mWordComposer.size() > Constants.MAX_CHARACTERS_FOR_SUGGESTIONS) {
             mSuggestionStripViewAccessor.setNeutralSuggestionStrip();
             return;
         }
@@ -2336,6 +2337,11 @@ public final class InputLogic {
     public void getSuggestedWords(final SettingsValues settingsValues,
             final Keyboard keyboard, final int keyboardShiftMode, final int inputStyle,
             final int sequenceNumber, final OnGetSuggestedWordsCallback callback) {
+        // don't get suggestions if composed word is very long
+        if (mWordComposer.size() > Constants.MAX_CHARACTERS_FOR_SUGGESTIONS) {
+            callback.onGetSuggestedWords(SuggestedWords.getEmptyInstance());
+            return;
+        }
         mWordComposer.adviseCapitalizedModeBeforeFetchingSuggestions(
                 getActualCapsMode(settingsValues, keyboardShiftMode));
         mSuggest.getSuggestedWords(mWordComposer,


### PR DESCRIPTION
Currently there are no suggestions in the URI fields which I feel like is not ideal for the privacy conscious users who have turned off auto-complete suggestions from the search engine. Gboard for example does show suggestions for url fields which is useful because there are many people who use that field in the browser to make search queries.
To make sure the suggestions are not annoying when an actual URLs is being entered, suggestions should stop if the composed word is longer than 20 characters (length of the English word "internationalization")
![url-suggestions](https://github.com/Helium314/HeliBoard/assets/151087174/daa9150d-cd80-4efa-822b-0a79a6adbf51)
