### PR TITLE
text to be committed is the middle suggestion

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/Suggest.kt
+++ b/app/src/main/java/helium314/keyboard/latin/Suggest.kt
@@ -115,13 +115,15 @@ class Suggest(private val mDictionaryFacilitator: DictionaryFacilitator) {
             inputStyleIfNotPrediction
         }
 
-        if (hasAutoCorrection) {
-            // make sure typed word is shown, so user is able to override incoming autocorrection
+        // If there is no autocorrection, and autocorrection setting is enabled, show the typed word in the middle.
+        // If there is an incoming autocorrection, make sure typed word is shown, so user is able to override it.
+        val typedIndex = if (hasAutoCorrection) 2 else 1
+        if (Settings.getInstance().current.mAutoCorrectEnabled && suggestionsList.size >= typedIndex) {
             if (typedWordFirstOccurrenceWordInfo != null) {
                 if (SuggestionStripView.DEBUG_SUGGESTIONS) addDebugInfo(typedWordFirstOccurrenceWordInfo, typedWordString)
-                suggestionsList.add(2, typedWordFirstOccurrenceWordInfo)
-            } else {
-                suggestionsList.add(2,
+                suggestionsList.add(typedIndex, typedWordFirstOccurrenceWordInfo)
+            } else if (typedWordString.isNotEmpty()){
+                suggestionsList.add(typedIndex,
                     SuggestedWordInfo(typedWordString, "", 0, SuggestedWordInfo.KIND_TYPED,
                         Dictionary.DICTIONARY_USER_TYPED, SuggestedWordInfo.NOT_AN_INDEX, SuggestedWordInfo.NOT_A_CONFIDENCE)
                 )

--- a/app/src/main/java/helium314/keyboard/latin/Suggest.kt
+++ b/app/src/main/java/helium314/keyboard/latin/Suggest.kt
@@ -115,14 +115,15 @@ class Suggest(private val mDictionaryFacilitator: DictionaryFacilitator) {
             inputStyleIfNotPrediction
         }
 
-        // If there is no autocorrection, and autocorrection setting is enabled, show the typed word in the middle.
         // If there is an incoming autocorrection, make sure typed word is shown, so user is able to override it.
+        // Otherwise, if the relevant setting is enabled, show the typed word in the middle.
         val typedIndex = if (hasAutoCorrection) 2 else 1
-        if (Settings.getInstance().current.mAutoCorrectEnabled && suggestionsList.size >= typedIndex) {
+        if ((hasAutoCorrection || Settings.getInstance().current.mCenterSuggestionTextToCommit)
+            && suggestionsList.size >= typedIndex && !TextUtils.isEmpty(typedWordString)) {
             if (typedWordFirstOccurrenceWordInfo != null) {
                 if (SuggestionStripView.DEBUG_SUGGESTIONS) addDebugInfo(typedWordFirstOccurrenceWordInfo, typedWordString)
                 suggestionsList.add(typedIndex, typedWordFirstOccurrenceWordInfo)
-            } else if (typedWordString.isNotEmpty()){
+            } else {
                 suggestionsList.add(typedIndex,
                     SuggestedWordInfo(typedWordString, "", 0, SuggestedWordInfo.KIND_TYPED,
                         Dictionary.DICTIONARY_USER_TYPED, SuggestedWordInfo.NOT_AN_INDEX, SuggestedWordInfo.NOT_A_CONFIDENCE)

--- a/app/src/main/java/helium314/keyboard/latin/settings/CorrectionSettingsFragment.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/CorrectionSettingsFragment.java
@@ -76,6 +76,7 @@ public final class CorrectionSettingsFragment extends SubScreenFragment
         setPreferenceVisible(Settings.PREF_MORE_AUTO_CORRECTION, Settings.readAutoCorrectEnabled(getSharedPreferences()));
         setPreferenceVisible(Settings.PREF_ADD_TO_PERSONAL_DICTIONARY, getSharedPreferences().getBoolean(Settings.PREF_KEY_USE_PERSONALIZED_DICTS, true));
         setPreferenceVisible(Settings.PREF_ALWAYS_SHOW_SUGGESTIONS, getSharedPreferences().getBoolean(Settings.PREF_SHOW_SUGGESTIONS, true));
+        setPreferenceVisible(Settings.PREF_CENTER_SUGGESTION_TEXT_TO_COMMIT, getSharedPreferences().getBoolean(Settings.PREF_SHOW_SUGGESTIONS, true));
         turnOffLookupContactsIfNoPermission();
     }
 

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -87,6 +87,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_AUTO_CORRECTION = "auto_correction";
     public static final String PREF_MORE_AUTO_CORRECTION = "more_auto_correction";
     public static final String PREF_AUTO_CORRECTION_CONFIDENCE = "auto_correction_confidence";
+    public static final String PREF_CENTER_SUGGESTION_TEXT_TO_COMMIT = "center_suggestion_text_to_commit";
     public static final String PREF_SHOW_SUGGESTIONS = "show_suggestions";
     public static final String PREF_ALWAYS_SHOW_SUGGESTIONS = "always_show_suggestions";
     public static final String PREF_KEY_USE_PERSONALIZED_DICTS = "use_personalized_dicts";
@@ -285,6 +286,10 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static String readAutoCorrectConfidence(final SharedPreferences prefs, final Resources res) {
         return prefs.getString(PREF_AUTO_CORRECTION_CONFIDENCE,
                 res.getString(R.string.auto_correction_threshold_mode_index_modest));
+    }
+
+    public static boolean readCenterSuggestionTextToCommit(final SharedPreferences prefs, final Resources res) {
+        return prefs.getBoolean(PREF_CENTER_SUGGESTION_TEXT_TO_COMMIT, res.getBoolean(R.bool.config_center_suggestion_text_to_commit));
     }
 
     public static boolean readBlockPotentiallyOffensive(final SharedPreferences prefs, final Resources res) {

--- a/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
@@ -87,6 +87,7 @@ public class SettingsValues {
     public final List<String> mPopupKeyLabelSources;
     public final List<Locale> mSecondaryLocales;
     public final boolean mBigramPredictionEnabled;// Use bigrams to predict the next word when there is no input for it yet
+    public final boolean mCenterSuggestionTextToCommit;
     public final boolean mGestureInputEnabled;
     public final boolean mGestureTrailEnabled;
     public final boolean mGestureFloatingPreviewTextEnabled;
@@ -161,6 +162,7 @@ public class SettingsValues {
         mAutoCorrectEnabled = mAutoCorrectionEnabledPerUserSettings
                 && (mInputAttributes.mInputTypeShouldAutoCorrect || Settings.readMoreAutoCorrectEnabled(prefs))
                 && (mUrlDetectionEnabled || !InputTypeUtils.isUriOrEmailType(mInputAttributes.mInputType));
+        mCenterSuggestionTextToCommit = Settings.readCenterSuggestionTextToCommit(prefs, res);
         mAutoCorrectionThreshold = mAutoCorrectEnabled
                 ? readAutoCorrectionThreshold(res, prefs)
                 : AUTO_CORRECTION_DISABLED_THRESHOLD;

--- a/app/src/main/res/values/config-common.xml
+++ b/app/src/main/res/values/config-common.xml
@@ -6,6 +6,8 @@
 -->
 
 <resources>
+    <!-- By default, the centered suggestion will not show the word that should be committed -->
+    <bool name="config_center_suggestion_text_to_commit">false</bool>
     <bool name="config_block_potentially_offensive">true</bool>
     <!-- Default value for next word prediction: after entering a word and a space only, should we
          look at input history to suggest a hopefully helpful suggestions for the next word? -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,6 +124,10 @@
     <string name="auto_correction_threshold_mode_aggressive">Aggressive</string>
     <!-- Option to suggest auto correction suggestions very aggressively. Auto-corrects to a word which has even large edit distance from typed word. [CHAR LIMIT=20] -->
     <string name="auto_correction_threshold_mode_very_aggressive">Very aggressive</string>
+    <!-- Option to show the text to be committed as the middle middle suggestion -->
+    <string name="center_suggestion_text_to_commit">Center text to commit</string>
+    <!-- Description for the center text to commit setting -->
+    <string name="center_suggestion_text_to_commit_summary">If enabled, the middle suggestion will show the text to be committed</string>
     <!-- Option to enable using next word suggestions. After the user types a space, with this option on, the keyboard will try to predict the next word. -->
     <string name="bigram_prediction">Next-word suggestions</string>
     <!-- Description for "next word suggestion" option. This displays suggestions even when there is no input, based on the previous word. -->

--- a/app/src/main/res/xml/prefs_screen_correction.xml
+++ b/app/src/main/res/xml/prefs_screen_correction.xml
@@ -100,6 +100,13 @@
             android:persistent="true" />
 
         <SwitchPreference
+            android:key="center_suggestion_text_to_commit"
+            android:title="@string/center_suggestion_text_to_commit"
+            android:summary="@string/center_suggestion_text_to_commit_summary"
+            android:defaultValue="@bool/config_center_suggestion_text_to_commit"
+            android:persistent="true" />
+
+        <SwitchPreference
             android:key="use_contacts"
             android:title="@string/use_contacts_dict"
             android:summary="@string/use_contacts_dict_summary"


### PR DESCRIPTION
Fixes #658
~~After testing it for a while there does not seem to be a need for a separate setting to toggle this functionality.
The change has effect only if autocorrect is enabled and it seems very intuitive that the middle suggestion should be the text that will be committed should the space key be pressed.~~
Nevermind, I may be able to see why some individuals may not be crazy about it. So I've added a setting (off by default) called "Center text to commit".
It is under Suggestions settings and can be activated even if autocorrect is disabled, although it makes more sense to do so when it autocorrect is on.