### PR TITLE
cut toolbar key

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardHistoryView.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardHistoryView.kt
@@ -69,7 +69,7 @@ class ClipboardHistoryView @JvmOverloads constructor(
         //  even when state is activated, the not activated color is set
         //   in suggestionStripView the same thing works correctly, wtf?
         //  need to properly fix it (and maybe undo the inverted isActivated) when adding a toggle key
-        listOf(ToolbarKey.LEFT, ToolbarKey.RIGHT, ToolbarKey.COPY, ToolbarKey.CLEAR_CLIPBOARD, ToolbarKey.SELECT_WORD, ToolbarKey.SELECT_ALL, ToolbarKey.CLOSE_HISTORY)
+        listOf(ToolbarKey.LEFT, ToolbarKey.RIGHT, ToolbarKey.COPY, ToolbarKey.CUT, ToolbarKey.CLEAR_CLIPBOARD, ToolbarKey.SELECT_WORD, ToolbarKey.SELECT_ALL, ToolbarKey.CLOSE_HISTORY)
             .forEach { toolbarKeys.add(createToolbarKey(context, keyboardAttr, it)) }
         keyboardAttr.recycle()
     }

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/KeyboardIconsSet.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/KeyboardIconsSet.java
@@ -52,6 +52,7 @@ public final class KeyboardIconsSet {
     public static final String NAME_CLIPBOARD_ACTION_KEY = "clipboard_action_key";
     public static final String NAME_CLIPBOARD_NORMAL_KEY = "clipboard_normal_key";
     public static final String NAME_CLEAR_CLIPBOARD_KEY = "clear_clipboard_key";
+    public static final String NAME_CUT_KEY = "cut_key";
     public static final String NAME_NUMPAD_KEY = "numpad_key";
     public static final String NAME_START_ONEHANDED_KEY = "start_onehanded_mode_key";
     public static final String NAME_STOP_ONEHANDED_KEY = "stop_onehanded_mode_key";
@@ -89,6 +90,7 @@ public final class KeyboardIconsSet {
         NAME_CLIPBOARD_ACTION_KEY,        R.styleable.Keyboard_iconClipboardActionKey,
         NAME_CLIPBOARD_NORMAL_KEY,        R.styleable.Keyboard_iconClipboardNormalKey,
         NAME_CLEAR_CLIPBOARD_KEY,         R.styleable.Keyboard_iconClearClipboardKey,
+        NAME_CUT_KEY,                     R.styleable.Keyboard_iconCutKey,
         NAME_NUMPAD_KEY,                  R.styleable.Keyboard_iconNumpadKey,
         NAME_START_ONEHANDED_KEY,         R.styleable.Keyboard_iconStartOneHandedMode,
         NAME_STOP_ONEHANDED_KEY,          R.styleable.Keyboard_iconStopOneHandedMode,

--- a/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
@@ -716,6 +716,15 @@ public final class InputLogic {
             case KeyCode.CLIPBOARD_COPY:
                 mConnection.copyText();
                 break;
+            case KeyCode.CLIPBOARD_CUT:
+                if (mConnection.hasSelection()) {
+                    mConnection.copyText();
+                    final Event backspaceEvent = LatinIME.createSoftwareKeypressEvent(KeyCode.DELETE,
+                            event.getMX(), event.getMY(), event.isKeyRepeat());
+                    handleBackspaceEvent(backspaceEvent, inputTransaction, currentKeyboardScript);
+                    inputTransaction.setDidAffectContents();
+                }
+                break;
             case KeyCode.ARROW_LEFT:
                 sendDownUpKeyEvent(KeyEvent.KEYCODE_DPAD_LEFT);
                 break;

--- a/app/src/main/java/helium314/keyboard/latin/utils/ToolbarUtils.kt
+++ b/app/src/main/java/helium314/keyboard/latin/utils/ToolbarUtils.kt
@@ -43,6 +43,7 @@ fun getCodeForToolbarKey(key: ToolbarKey) = when (key) {
     CLIPBOARD -> KeyCode.CLIPBOARD
     SELECT_ALL -> KeyCode.CLIPBOARD_SELECT_ALL
     COPY -> KeyCode.CLIPBOARD_COPY
+    CUT -> KeyCode.CLIPBOARD_CUT
     ONE_HANDED -> if (Settings.getInstance().current.mOneHandedModeEnabled) KeyCode.STOP_ONE_HANDED_MODE else KeyCode.START_ONE_HANDED_MODE
     LEFT -> KeyCode.ARROW_LEFT
     RIGHT -> KeyCode.ARROW_RIGHT
@@ -65,6 +66,7 @@ private fun getStyleableIconId(key: ToolbarKey) = when (key) {
     CLIPBOARD -> R.styleable.Keyboard_iconClipboardNormalKey
     SELECT_ALL -> R.styleable.Keyboard_iconSelectAll
     COPY -> R.styleable.Keyboard_iconCopyKey
+    CUT -> R.styleable.Keyboard_iconCutKey
     ONE_HANDED -> R.styleable.Keyboard_iconStartOneHandedMode
     LEFT -> R.styleable.Keyboard_iconArrowLeft
     RIGHT -> R.styleable.Keyboard_iconArrowRight
@@ -92,7 +94,7 @@ fun getToolbarIconByName(name: String, context: Context): Drawable? {
 
 // names need to be aligned with resources strings (using lowercase of key.name)
 enum class ToolbarKey {
-    VOICE, CLIPBOARD, UNDO, REDO, SETTINGS, SELECT_ALL, SELECT_WORD, COPY, ONE_HANDED, LEFT, RIGHT, UP, DOWN,
+    VOICE, CLIPBOARD, UNDO, REDO, SETTINGS, SELECT_ALL, SELECT_WORD, COPY, CUT, ONE_HANDED, LEFT, RIGHT, UP, DOWN,
     FULL_LEFT, FULL_RIGHT, INCOGNITO, AUTOCORRECT, CLEAR_CLIPBOARD, CLOSE_HISTORY
 }
 
@@ -100,7 +102,7 @@ fun toToolbarKeyString(keys: Collection<ToolbarKey>) = keys.joinToString(";") { 
 
 val defaultToolbarPref = entries.filterNot { it == CLEAR_CLIPBOARD || it == CLOSE_HISTORY }.joinToString(";") {
     when (it) {
-        INCOGNITO, AUTOCORRECT, UP, DOWN, ONE_HANDED, FULL_LEFT, FULL_RIGHT -> "${it.name},false"
+        INCOGNITO, AUTOCORRECT, UP, DOWN, ONE_HANDED, FULL_LEFT, FULL_RIGHT, CUT -> "${it.name},false"
         else -> "${it.name},true"
     }
 }

--- a/app/src/main/res/drawable/sym_keyboard_cut.xml
+++ b/app/src/main/res/drawable/sym_keyboard_cut.xml
@@ -1,0 +1,12 @@
+<!--
+    icon available in Android Studio
+    SPDX-License-Identifier: Apache-2.0
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24">
+    <path android:fillColor="#FFF"
+        android:pathData="M9.64,7.64c0.23,-0.5 0.36,-1.05 0.36,-1.64 0,-2.21 -1.79,-4 -4,-4S2,3.79 2,6s1.79,4 4,4c0.59,0 1.14,-0.13 1.64,-0.36L10,12l-2.36,2.36C7.14,14.13 6.59,14 6,14c-2.21,0 -4,1.79 -4,4s1.79,4 4,4 4,-1.79 4,-4c0,-0.59 -0.13,-1.14 -0.36,-1.64L12,14l7,7h3v-1L9.64,7.64zM6,8c-1.1,0 -2,-0.89 -2,-2s0.9,-2 2,-2 2,0.89 2,2 -0.9,2 -2,2zM6,20c-1.1,0 -2,-0.89 -2,-2s0.9,-2 2,-2 2,0.89 2,2 -0.9,2 -2,2zM12,12.5c-0.28,0 -0.5,-0.22 -0.5,-0.5s0.22,-0.5 0.5,-0.5 0.5,0.22 0.5,0.5 -0.22,0.5 -0.5,0.5zM19,3l-6,6 2,2 7,-7L22,3z"/>
+</vector>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -260,6 +260,7 @@
         <attr name="iconClipboardActionKey" format="reference" />
         <attr name="iconClipboardNormalKey" format="reference" />
         <attr name="iconCopyKey" format="reference" />
+        <attr name="iconCutKey" format="reference" />
         <attr name="iconClearClipboardKey" format="reference" />
         <attr name="iconStartOneHandedMode" format="reference" />
         <attr name="iconStopOneHandedMode" format="reference" />

--- a/app/src/main/res/values/keyboard-icons-holo.xml
+++ b/app/src/main/res/values/keyboard-icons-holo.xml
@@ -29,6 +29,7 @@
         <item name="iconClipboardActionKey">@drawable/sym_keyboard_clipboard_holo</item>
         <item name="iconClipboardNormalKey">@drawable/sym_keyboard_clipboard_holo</item>
         <item name="iconCopyKey">@drawable/sym_keyboard_copy</item>
+        <item name="iconCutKey">@drawable/sym_keyboard_cut</item>
         <item name="iconClearClipboardKey">@drawable/sym_keyboard_clear_clipboard_holo</item>
         <item name="iconStartOneHandedMode">@drawable/sym_keyboard_start_onehanded_holo</item>
         <item name="iconStopOneHandedMode">@drawable/sym_keyboard_stop_onehanded_holo</item>

--- a/app/src/main/res/values/keyboard-icons-lxx-light.xml
+++ b/app/src/main/res/values/keyboard-icons-lxx-light.xml
@@ -34,6 +34,7 @@
         <item name="iconClipboardActionKey">@drawable/sym_keyboard_clipboard_lxx</item>
         <item name="iconClipboardNormalKey">@drawable/sym_keyboard_clipboard_lxx</item>
         <item name="iconCopyKey">@drawable/sym_keyboard_copy</item>
+        <item name="iconCutKey">@drawable/sym_keyboard_cut</item>
         <item name="iconClearClipboardKey">@drawable/sym_keyboard_clear_clipboard_lxx</item>
         <item name="iconStartOneHandedMode">@drawable/sym_keyboard_start_onehanded_lxx</item>
         <item name="iconStopOneHandedMode">@drawable/sym_keyboard_stop_onehanded_lxx</item>

--- a/app/src/main/res/values/keyboard-icons-rounded.xml
+++ b/app/src/main/res/values/keyboard-icons-rounded.xml
@@ -33,6 +33,7 @@
         <item name="iconClipboardActionKey">@drawable/sym_keyboard_clipboard_rounded</item>
         <item name="iconClipboardNormalKey">@drawable/sym_keyboard_clipboard_rounded</item>
         <item name="iconCopyKey">@drawable/sym_keyboard_copy_rounded</item>
+        <item name="iconCutKey">@drawable/sym_keyboard_cut</item>
         <item name="iconClearClipboardKey">@drawable/sym_keyboard_clear_clipboard_rounded</item>
         <item name="iconStartOneHandedMode">@drawable/sym_keyboard_start_onehanded_rounded</item>
         <item name="iconStopOneHandedMode">@drawable/sym_keyboard_stop_onehanded_rounded</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -229,6 +229,7 @@
     <string name="toolbar_keys">Select toolbar keys</string>
     <!-- Names of the toolbar keys-->
     <string name="copy" tools:keep="@string/copy" translatable="false">@android:string/copy</string>
+    <string name="cut" tools:keep="@string/Cut">Cut</string>
     <string name="clipboard" tools:keep="@string/clipboard">Clipboard</string>
     <string name="clear_clipboard" tools:keep="@string/clear_clipboard">Clear clipboard</string>
     <string name="voice" tools:keep="@string/voice">Voice input</string>


### PR DESCRIPTION
fixes #571

![cut](https://github.com/Helium314/HeliBoard/assets/151087174/c79207b3-cd4e-4e32-859b-4df7f83c20e5)

also visible in the clipboard history view