### PR TITLE
separate clipboard history

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/RichInputConnection.java
+++ b/app/src/main/java/helium314/keyboard/latin/RichInputConnection.java
@@ -653,7 +653,7 @@ public final class RichInputConnection implements PrivateCommandPerformer {
         mIC.setSelection(mExpectedSelStart - range.getNumberOfCharsInWordBeforeCursor(), mExpectedSelStart + range.getNumberOfCharsInWordAfterCursor());
     }
 
-    public void copyText() {
+    public void copyText(final ClipboardHistoryManager clipboardHistoryManager, final boolean syncToPrimaryClipboard) {
         // copy selected text, and if nothing is selected copy the whole text
         CharSequence text = getSelectedText(InputConnection.GET_TEXT_WITH_STYLES);
         if (text == null || text.length() == 0) {
@@ -666,8 +666,12 @@ public final class RichInputConnection implements PrivateCommandPerformer {
             text = et.text;
         }
         if (text == null || text.length() == 0) return;
-        final ClipboardManager cm = (ClipboardManager) mParent.getSystemService(Context.CLIPBOARD_SERVICE);
-        cm.setPrimaryClip(ClipData.newPlainText("copied text", text));
+        if (syncToPrimaryClipboard) {
+            final ClipboardManager cm = (ClipboardManager) mParent.getSystemService(Context.CLIPBOARD_SERVICE);
+            cm.setPrimaryClip(ClipData.newPlainText("copied text", text));
+        } else if (clipboardHistoryManager != null) {
+            clipboardHistoryManager.copyTextToInternalClipboard(text, System.currentTimeMillis());
+        }
     }
 
     public void commitCorrection(final CorrectionInfo correctionInfo) {

--- a/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
@@ -714,11 +714,13 @@ public final class InputLogic {
                 mConnection.selectWord(inputTransaction.getMSettingsValues().mSpacingAndPunctuations, currentKeyboardScript);
                 break;
             case KeyCode.CLIPBOARD_COPY:
-                mConnection.copyText();
+                mConnection.copyText(mLatinIME.getClipboardHistoryManager(),
+                        inputTransaction.getMSettingsValues().mSyncToPrimaryClipboard);
                 break;
             case KeyCode.CLIPBOARD_CUT:
                 if (mConnection.hasSelection()) {
-                    mConnection.copyText();
+                    mConnection.copyText(mLatinIME.getClipboardHistoryManager(),
+                            inputTransaction.getMSettingsValues().mSyncToPrimaryClipboard);
                     // fake delete keypress to remove the text
                     final Event backspaceEvent = LatinIME.createSoftwareKeypressEvent(KeyCode.DELETE,
                             event.getMX(), event.getMY(), event.isKeyRepeat());

--- a/app/src/main/java/helium314/keyboard/latin/settings/PreferencesSettingsFragment.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/PreferencesSettingsFragment.java
@@ -126,6 +126,10 @@ public final class PreferencesSettingsFragment extends SubScreenFragment {
                 Settings.readKeypressSoundEnabled(prefs, res));
         setPreferenceVisible(Settings.PREF_CLIPBOARD_HISTORY_RETENTION_TIME,
                 Settings.readClipboardHistoryEnabled(prefs));
+        setPreferenceVisible(Settings.PREF_SYNC_TO_PRIMARY_CLIPBOARD,
+                Settings.readClipboardHistoryEnabled(prefs));
+        setPreferenceVisible(Settings.PREF_SYNC_FROM_PRIMARY_CLIPBOARD,
+                Settings.readClipboardHistoryEnabled(prefs));
     }
 
     private void setupKeypressVibrationDurationSettings() {

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -136,6 +136,8 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
 
     public static final String PREF_ENABLE_CLIPBOARD_HISTORY = "enable_clipboard_history";
     public static final String PREF_CLIPBOARD_HISTORY_RETENTION_TIME = "clipboard_history_retention_time";
+    public static final String PREF_SYNC_FROM_PRIMARY_CLIPBOARD = "sync_from_primary_clipboard";
+    public static final String PREF_SYNC_TO_PRIMARY_CLIPBOARD = "sync_to_primary_clipboard";
 
     public static final String PREF_SECONDARY_LOCALES_PREFIX = "secondary_locales_";
     public static final String PREF_ADD_TO_PERSONAL_DICTIONARY = "add_to_personal_dictionary";
@@ -385,6 +387,14 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
 
     public static int readDefaultClipboardHistoryRetentionTime(final Resources res) {
         return res.getInteger(R.integer.config_clipboard_history_retention_time);
+    }
+
+    public static boolean readSyncFromPrimaryClipboard(SharedPreferences prefs) {
+        return prefs.getBoolean(PREF_SYNC_FROM_PRIMARY_CLIPBOARD, true);
+    }
+
+    public static boolean readSyncToPrimaryClipboard(SharedPreferences prefs) {
+        return prefs.getBoolean(PREF_SYNC_TO_PRIMARY_CLIPBOARD, true);
     }
 
     public static int readHorizontalSpaceSwipe(final SharedPreferences prefs) {

--- a/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
@@ -77,6 +77,8 @@ public class SettingsValues {
     public final boolean mDeleteSwipeEnabled;
     public final boolean mAutospaceAfterPunctuationEnabled;
     public final boolean mClipboardHistoryEnabled;
+    public final boolean mSyncFromPrimaryClipboard;
+    public final boolean mSyncToPrimaryClipboard;
     public final long mClipboardHistoryRetentionTime;
     public final boolean mOneHandedModeEnabled;
     public final int mOneHandedModeGravity;
@@ -200,7 +202,8 @@ public class SettingsValues {
         mAutospaceAfterPunctuationEnabled = Settings.readAutospaceAfterPunctuationEnabled(prefs);
         mClipboardHistoryEnabled = Settings.readClipboardHistoryEnabled(prefs);
         mClipboardHistoryRetentionTime = Settings.readClipboardHistoryRetentionTime(prefs, res);
-
+        mSyncFromPrimaryClipboard = mClipboardHistoryEnabled && Settings.readSyncFromPrimaryClipboard(prefs);
+        mSyncToPrimaryClipboard = mClipboardHistoryEnabled && Settings.readSyncToPrimaryClipboard(prefs);
         mOneHandedModeEnabled = Settings.readOneHandedModeEnabled(prefs, mDisplayOrientation == Configuration.ORIENTATION_PORTRAIT);
         mOneHandedModeGravity = Settings.readOneHandedModeGravity(prefs, mDisplayOrientation == Configuration.ORIENTATION_PORTRAIT);
         if (mOneHandedModeEnabled) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,6 +148,14 @@
     <string name="enable_clipboard_history_summary">If disabled, clipboard key will paste clipboard content if any</string>
     <!-- Preferences item for enabling clipboard history -->
     <string name="clipboard_history_retention_time">History retention time</string>
+    <!-- Preferences item for syncing the internal clipboard to the primary clipboard -->
+    <string name="sync_to_primary_clipboard">Sync to primary clipboard</string>
+    <!-- Description for "sync_to_primary_clipboard" option. If disabled, copy/cut toolbar keys will sync to the internal clipboard only -->
+    <string name="sync_to_primary_clipboard_summary">Control whether the internal clipboard should sync to the primary clipboard</string>
+    <!-- Preferences item for syncing the primary clipboard to the internal clipboard -->
+    <string name="sync_from_primary_clipboard">Sync from primary clipboard</string>
+    <!-- Description for "sync_from_primary_clipboard" option. If disabled, primary clipboard content won't be stored in history -->
+    <string name="sync_from_primary_clipboard_summary">Control whether the primary clipboard should sync to the internal clipboard</string>
     <!-- Preferences item for enabling swipe deletion -->
     <string name="delete_swipe">Delete swipe</string>
     <!-- Description for "delete_swipe" option. -->

--- a/app/src/main/res/xml/prefs_screen_preferences.xml
+++ b/app/src/main/res/xml/prefs_screen_preferences.xml
@@ -121,6 +121,20 @@
             android:title="@string/clipboard_history_retention_time"
             latin:maxValue="120" /> <!-- minutes -->
 
+        <SwitchPreference
+            android:key="sync_from_primary_clipboard"
+            android:title="@string/sync_from_primary_clipboard"
+            android:summary="@string/sync_from_primary_clipboard_summary"
+            android:defaultValue="true"
+            android:persistent="true" />
+
+        <SwitchPreference
+            android:key="sync_to_primary_clipboard"
+            android:title="@string/sync_to_primary_clipboard"
+            android:summary="@string/sync_to_primary_clipboard_summary"
+            android:defaultValue="true"
+            android:persistent="true" />
+
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
I added 2 settings to control the clipboard syncing from/to the primary clipboard so the internal clipboard can be separated from the primary one. it should fix #306 