### PR TITLE
do not coerce non-text clipboard content

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
+++ b/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
@@ -48,7 +48,7 @@ class ClipboardHistoryManager(
 
     private fun fetchPrimaryClip() {
         val clipData = clipboardManager.primaryClip ?: return
-        if (clipData.itemCount == 0) return
+        if (clipData.itemCount == 0 || clipData.description?.hasMimeType("text/*") == false) return
         clipData.getItemAt(0)?.let { clipItem ->
             val timeStamp = ClipboardManagerCompat.getClipTimestamp(clipData) ?: System.currentTimeMillis()
             val content = clipItem.coerceToText(latinIME)


### PR DESCRIPTION
The internal clipboard history adds all clipboard mime types even if it is non-text (like an image media type), and that causes the keyboard to freeze for a few moments before the history view is opened after copying an image to the clipboard, especially noticeable if the image is hi-res.

![coerce](https://github.com/Helium314/HeliBoard/assets/151087174/3b3fd971-01b2-4eab-9be4-62d77318a609)

Reproducible at least in recent OneUI versions which have the "Copy to clipboard" context menu in the Gallery app

Until clipboard images are supported, there is no need to coerce mime types that are not text.

Shoutout to @RHJihan for noticing this bug