### PR TITLE
fix deallocated clipboard/emoji views

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardSwitcher.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardSwitcher.java
@@ -540,10 +540,10 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
             mKeyboardView.cancelAllOngoingEvents();
             mKeyboardView.deallocateMemory();
         }
-        if (!isShowingEmojiPalettes()) {
+        if (mEmojiPalettesView != null) {
             mEmojiPalettesView.stopEmojiPalettes();
         }
-        if (!isShowingClipboardHistory()) {
+        if (mClipboardHistoryView != null) {
             mClipboardHistoryView.stopClipboardHistory();
         }
     }

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardSwitcher.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardSwitcher.java
@@ -540,10 +540,10 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
             mKeyboardView.cancelAllOngoingEvents();
             mKeyboardView.deallocateMemory();
         }
-        if (mEmojiPalettesView != null) {
+        if (!isShowingEmojiPalettes()) {
             mEmojiPalettesView.stopEmojiPalettes();
         }
-        if (mClipboardHistoryView != null) {
+        if (!isShowingClipboardHistory()) {
             mClipboardHistoryView.stopClipboardHistory();
         }
     }

--- a/app/src/main/java/helium314/keyboard/latin/LatinIME.java
+++ b/app/src/main/java/helium314/keyboard/latin/LatinIME.java
@@ -726,6 +726,8 @@ public class LatinIME extends InputMethodService implements
         unregisterReceiver(mRestartAfterDeviceUnlockReceiver);
         mStatsUtilsManager.onDestroy(this /* context */);
         super.onDestroy();
+        mHandler.removeCallbacksAndMessages(null);
+        deallocateMemory();
     }
 
     public void recycle() {


### PR DESCRIPTION
When keyboard instance is destroyed (such as by switching to another keyboard), postDeallocateMemory() is issued by the handler of LatinIME, and the clipboard and emoji views memory is deallocated after 10 seconds (the delay of the message) even if the keyboard instance is recreated in the meantime.
cancelDeallocateMemory() does not seem to remove the pending message for some reason.
That causes all emojis/clipboard entries to suddenly vanish.

Here is a video taken from #616 showing how to reproduce the bug (credit to @Uranusek)

https://github.com/Helium314/HeliBoard/assets/151087174/a6a43d52-fcf7-4515-887b-9019392212be

With the small check I altered, the memory of those views will not be deallocated any longer when they are visible