### PR TITLE
key press popup text cut off

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/MainKeyboardView.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/MainKeyboardView.java
@@ -83,7 +83,6 @@ import java.util.WeakHashMap;
  * @attr ref R.styleable#MainKeyboardView_ignoreAltCodeKeyTimeout
  * @attr ref R.styleable#MainKeyboardView_keyPreviewLayout
  * @attr ref R.styleable#MainKeyboardView_keyPreviewOffset
- * @attr ref R.styleable#MainKeyboardView_keyPreviewHeight
  * @attr ref R.styleable#MainKeyboardView_popupKeysKeyboardLayout
  * @attr ref R.styleable#MainKeyboardView_popupKeysKeyboardForActionLayout
  * @attr ref R.styleable#MainKeyboardView_backgroundDimAlpha

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/KeyPreviewChoreographer.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/KeyPreviewChoreographer.java
@@ -89,7 +89,7 @@ public final class KeyPreviewChoreographer {
         keyPreviewView.measure(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
         mParams.setGeometry(keyPreviewView);
         final int previewWidth = keyPreviewView.getMeasuredWidth();
-        final int previewHeight = mParams.mPreviewHeight;
+        final int previewHeight = keyPreviewView.getMeasuredHeight();
         final int keyDrawWidth = key.getDrawWidth();
         // The key preview is horizontally aligned with the center of the visible part of the
         // parent key. If it doesn't fit in this {@link KeyboardView}, it is moved inward to fit and

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/KeyPreviewDrawParams.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/KeyPreviewDrawParams.java
@@ -15,7 +15,6 @@ import helium314.keyboard.latin.settings.Settings;
 public final class KeyPreviewDrawParams {
     // XML attributes of {@link MainKeyboardView}.
     public final int mPreviewOffset;
-    public final int mPreviewHeight;
     public final int mPreviewBackgroundResId;
     private boolean mShowPopup = true;
 
@@ -47,13 +46,6 @@ public final class KeyPreviewDrawParams {
     public KeyPreviewDrawParams(final TypedArray mainKeyboardViewAttr) {
         mPreviewOffset = mainKeyboardViewAttr.getDimensionPixelOffset(
                 R.styleable.MainKeyboardView_keyPreviewOffset, 0);
-        // crashes when too small (or just < 1?)
-        final float heightScale = (float) Math.max(1f, Math.sqrt(Settings.getInstance().getCurrent().mKeyboardHeightScale));
-        // todo: further scaling issue
-        //  key height and thus text height (in pixels) don't change with display density,
-        //  but keyPreviewHeight does -> how to do it right?
-        mPreviewHeight = (int) (mainKeyboardViewAttr.getDimensionPixelSize(
-                R.styleable.MainKeyboardView_keyPreviewHeight, 0) * heightScale);
         mPreviewBackgroundResId = mainKeyboardViewAttr.getResourceId(
                 R.styleable.MainKeyboardView_keyPreviewBackground, 0);
     }
@@ -68,10 +60,11 @@ public final class KeyPreviewDrawParams {
 
     public void setGeometry(final View previewTextView) {
         final int previewWidth = previewTextView.getMeasuredWidth();
+        final int previewHeight = previewTextView.getMeasuredHeight();
         // The width and height of visible part of the key preview background. The content marker
         // of the background 9-patch have to cover the visible part of the background.
         mVisibleWidth = previewWidth - previewTextView.getPaddingLeft() - previewTextView.getPaddingRight();
-        mVisibleHeight = mPreviewHeight - previewTextView.getPaddingTop() - previewTextView.getPaddingBottom();
+        mVisibleHeight = previewHeight - previewTextView.getPaddingTop() - previewTextView.getPaddingBottom();
         // The distance between the top edge of the parent key and the bottom of the visible part
         // of the key preview background.
         setVisibleOffset(-previewTextView.getPaddingBottom() / 2);

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/KeyPreviewView.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/KeyPreviewView.java
@@ -40,7 +40,7 @@ public class KeyPreviewView extends AppCompatTextView {
 
     public KeyPreviewView(final Context context, final AttributeSet attrs, final int defStyleAttr) {
         super(context, attrs, defStyleAttr);
-        setGravity(Gravity.BOTTOM | Gravity.CENTER_HORIZONTAL);
+        setGravity(Gravity.CENTER);
     }
 
     public void setPreviewVisual(final Key key, final KeyboardIconsSet iconsSet,

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/KeyPreviewView.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/KeyPreviewView.java
@@ -40,7 +40,7 @@ public class KeyPreviewView extends AppCompatTextView {
 
     public KeyPreviewView(final Context context, final AttributeSet attrs, final int defStyleAttr) {
         super(context, attrs, defStyleAttr);
-        setGravity(Gravity.CENTER);
+        setGravity(Gravity.BOTTOM | Gravity.CENTER_HORIZONTAL);
     }
 
     public void setPreviewVisual(final Key key, final KeyboardIconsSet iconsSet,

--- a/app/src/main/res/values-land/config.xml
+++ b/app/src/main/res/values-land/config.xml
@@ -29,9 +29,7 @@
     <!-- config_popup_keys_keyboard_key_height x -0.5 -->
     <dimen name="config_popup_keys_keyboard_vertical_correction_holo">-22.4dp</dimen>
     <dimen name="config_key_preview_offset_holo">1.6dp</dimen>
-    <dimen name="config_key_preview_height_holo">80dp</dimen>
     <dimen name="config_key_preview_offset_lxx">0dp</dimen>
-    <dimen name="config_key_preview_height_lxx">122dp</dimen>
     <fraction name="config_key_preview_text_ratio">90%</fraction>
     <fraction name="config_key_letter_ratio_holo">65%</fraction>
     <fraction name="config_key_letter_ratio_lxx">65%</fraction>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -102,8 +102,6 @@
         <attr name="keyPreviewBackground" format="reference" />
         <!-- Vertical offset of the key press feedback from the key. -->
         <attr name="keyPreviewOffset" format="dimension" />
-        <!-- Height of the key press feedback popup. -->
-        <attr name="keyPreviewHeight" format="dimension" />
         <!-- Layout resource for popup keys keyboard -->
         <attr name="popupKeysKeyboardLayout" format="reference" />
         <!-- Layout resource for popup keys keyboard of action key -->

--- a/app/src/main/res/values/config.xml
+++ b/app/src/main/res/values/config.xml
@@ -38,7 +38,7 @@
     <dimen name="config_key_preview_height_holo">80dp</dimen>
     <dimen name="config_key_preview_offset_lxx">0dp</dimen>
     <dimen name="config_key_preview_height_lxx">111dp</dimen>
-    <fraction name="config_key_preview_text_ratio">65%</fraction>
+    <fraction name="config_key_preview_text_ratio">82%</fraction>
     <fraction name="config_key_letter_ratio_holo">55%</fraction>
     <fraction name="config_key_letter_ratio_lxx">55%</fraction>
     <fraction name="config_key_large_letter_ratio_holo">65%</fraction>

--- a/app/src/main/res/values/config.xml
+++ b/app/src/main/res/values/config.xml
@@ -35,9 +35,7 @@
     <!-- config_popup_keys_keyboard_key_height x -0.5 -->
     <dimen name="config_popup_keys_keyboard_vertical_correction_holo">-26.4dp</dimen>
     <dimen name="config_key_preview_offset_holo">40.0dp</dimen>
-    <dimen name="config_key_preview_height_holo">80dp</dimen>
     <dimen name="config_key_preview_offset_lxx">0dp</dimen>
-    <dimen name="config_key_preview_height_lxx">111dp</dimen>
     <fraction name="config_key_preview_text_ratio">82%</fraction>
     <fraction name="config_key_letter_ratio_holo">55%</fraction>
     <fraction name="config_key_letter_ratio_lxx">55%</fraction>

--- a/app/src/main/res/values/config.xml
+++ b/app/src/main/res/values/config.xml
@@ -38,7 +38,7 @@
     <dimen name="config_key_preview_height_holo">80dp</dimen>
     <dimen name="config_key_preview_offset_lxx">0dp</dimen>
     <dimen name="config_key_preview_height_lxx">111dp</dimen>
-    <fraction name="config_key_preview_text_ratio">82%</fraction>
+    <fraction name="config_key_preview_text_ratio">65%</fraction>
     <fraction name="config_key_letter_ratio_holo">55%</fraction>
     <fraction name="config_key_letter_ratio_lxx">55%</fraction>
     <fraction name="config_key_large_letter_ratio_holo">65%</fraction>

--- a/app/src/main/res/values/themes-holo_base.xml
+++ b/app/src/main/res/values/themes-holo_base.xml
@@ -56,7 +56,6 @@
         parent="KeyboardView.HoloBase"
     >
         <item name="keyPreviewBackground">@drawable/keyboard_key_feedback_holo_white</item>
-        <item name="keyPreviewHeight">@dimen/config_key_preview_height_holo</item>
         <item name="keyPreviewOffset">@dimen/config_key_preview_offset_holo</item>
         <item name="languageOnSpacebarTextShadowRadius">1.0</item>
         <item name="languageOnSpacebarTextShadowColor">@color/spacebar_text_shadow_color_holo</item>

--- a/app/src/main/res/values/themes-lxx-base.xml
+++ b/app/src/main/res/values/themes-lxx-base.xml
@@ -42,7 +42,6 @@
         >
         <item name="popupKeysKeyboardForActionLayout">@layout/popup_keys_keyboard_for_action_lxx</item>
         <item name="keyPreviewBackground">@drawable/keyboard_key_feedback_lxx_light</item>
-        <item name="keyPreviewHeight">@dimen/config_key_preview_height_lxx</item>
         <item name="keyPreviewOffset">@dimen/config_key_preview_offset_lxx</item>
         <!-- A negative value to disable text shadow layer. -->
         <item name="languageOnSpacebarTextShadowRadius">-1.0</item>

--- a/app/src/main/res/values/themes-rounded-base.xml
+++ b/app/src/main/res/values/themes-rounded-base.xml
@@ -48,7 +48,6 @@
         >
         <item name="popupKeysKeyboardForActionLayout">@layout/popup_keys_keyboard_for_action_lxx</item>
         <item name="keyPreviewBackground">@drawable/keyboard_key_feedback_lxx_light</item>
-        <item name="keyPreviewHeight">@dimen/config_key_preview_height_lxx</item>
         <item name="keyPreviewOffset">@dimen/config_key_preview_offset_lxx</item>
         <!-- A negative value to disable text shadow layer. -->
         <item name="languageOnSpacebarTextShadowRadius">-1.0</item>


### PR DESCRIPTION
I changed the gravity of the key preview view and it seems to fix #712, #166 on my 393dpi phone.
I've also tried it out in android studio with simulated displays of 560dpi (pixel 7 pro) and xhdpi (small phone) and it still looks right without cutoffs of high characters such as 'p', 'g' or '['