### PR TITLE
Push toolbar keys to the end of the container

### DIFF
--- a/app/src/main/res/layout/suggestions_strip.xml
+++ b/app/src/main/res/layout/suggestions_strip.xml
@@ -37,6 +37,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:orientation="horizontal"
+                android:layout_gravity="end"
                 style="?attr/suggestionWordStyle">
             </LinearLayout>
         </HorizontalScrollView>


### PR DESCRIPTION
I think it makes more sense to push the main toolbar keys to the end of the toolbar container, it looks more consistent that way when the toolbar is not full and some the its keys are pinned. It should now be easier to memorize the location of useful keys.

Before:

https://github.com/Helium314/HeliBoard/assets/151087174/a8f034c4-f57e-412a-9605-ad22919bcf37

After:

https://github.com/Helium314/HeliBoard/assets/151087174/ff2242c3-d1ba-400f-8d72-3bcaf78b2b35

This change also works correctly when an RTL subtype is selected and "Variable toolbar direction" setting is enabled
