### PR TITLE
add clipboard cleared toast

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
@@ -32,6 +32,7 @@ import helium314.keyboard.latin.DictionaryFacilitator;
 import helium314.keyboard.latin.LastComposedWord;
 import helium314.keyboard.latin.LatinIME;
 import helium314.keyboard.latin.NgramContext;
+import helium314.keyboard.latin.R;
 import helium314.keyboard.latin.RichInputConnection;
 import helium314.keyboard.latin.Suggest;
 import helium314.keyboard.latin.Suggest.OnGetSuggestedWordsCallback;
@@ -738,6 +739,7 @@ public final class InputLogic {
                 break;
             case KeyCode.CLIPBOARD_CLEAR_HISTORY:
                 mLatinIME.getClipboardHistoryManager().clearHistory();
+                KeyboardSwitcher.getInstance().showToast(mLatinIME.getString(R.string.toast_message_clear_clipboard), true);
                 break;
             case KeyCode.CLIPBOARD_CUT:
                 if (mConnection.hasSelection()) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -832,4 +832,6 @@ New dictionary:
     <string name="var_toolbar_direction_summary">Reverse direction when a right-to-left keyboard subtype is selected</string>
     <!-- Toast message shown when content is copied to the clipboard -->
     <string name="toast_msg_clipboard_copy">Content copied</string>
+    <!-- Toast message shown when clipboard history is cleared -->
+    <string name="toast_message_clear_clipboard">Clipboard cleared</string>
 </resources>


### PR DESCRIPTION
Now that #752 and #679 have been merged, I think it would be a good idea to show a toast as an indication that the "clear clipboard" toolbar key has been pressed.
![toast](https://github.com/Helium314/HeliBoard/assets/151087174/3872b7a7-3145-4d75-bd51-87e91636f6dc)
