### PR TITLE
toolbar modes

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardSwitcher.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardSwitcher.java
@@ -19,6 +19,7 @@ import android.view.View;
 import android.view.animation.AnimationUtils;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodSubtype;
+import android.widget.FrameLayout;
 import android.widget.HorizontalScrollView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -45,6 +46,7 @@ import helium314.keyboard.latin.utils.Log;
 import helium314.keyboard.latin.utils.RecapitalizeStatus;
 import helium314.keyboard.latin.utils.ResourceUtils;
 import helium314.keyboard.latin.utils.ScriptUtils;
+import helium314.keyboard.latin.utils.ToolbarMode;
 
 public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
     private static final String TAG = KeyboardSwitcher.class.getSimpleName();
@@ -58,6 +60,7 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
     private LinearLayout mClipboardStripView;
     private HorizontalScrollView mClipboardStripScrollView;
     private View mSuggestionStripView;
+    private FrameLayout mStripContainer;
     private ClipboardHistoryView mClipboardHistoryView;
     private TextView mFakeToastView;
     private LatinIME mLatinIME;
@@ -281,6 +284,7 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
             @NonNull final SettingsValues settingsValues,
             @NonNull final KeyboardSwitchState toggleState) {
         final int visibility = isImeSuppressedByHardwareKeyboard(settingsValues, toggleState) ? View.GONE : View.VISIBLE;
+        final int stripVisibility = settingsValues.mToolbarMode == ToolbarMode.HIDDEN ? View.GONE : View.VISIBLE;
         mKeyboardView.setVisibility(visibility);
         // The visibility of {@link #mKeyboardView} must be aligned with {@link #MainKeyboardFrame}.
         // @see #getVisibleKeyboardView() and
@@ -290,7 +294,8 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         mEmojiPalettesView.stopEmojiPalettes();
         mEmojiTabStripView.setVisibility(View.GONE);
         mClipboardStripScrollView.setVisibility(View.GONE);
-        mSuggestionStripView.setVisibility(View.VISIBLE);
+        mStripContainer.setVisibility(stripVisibility);
+        mSuggestionStripView.setVisibility(stripVisibility);
         mClipboardHistoryView.setVisibility(View.GONE);
         mClipboardHistoryView.stopClipboardHistory();
     }
@@ -308,6 +313,7 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         // @see LatinIME#onComputeInset(android.inputmethodservice.InputMethodService.Insets)
         mKeyboardView.setVisibility(View.GONE);
         mSuggestionStripView.setVisibility(View.GONE);
+        mStripContainer.setVisibility(View.VISIBLE);
         mClipboardStripScrollView.setVisibility(View.GONE);
         mEmojiTabStripView.setVisibility(View.VISIBLE);
         mClipboardHistoryView.setVisibility(View.GONE);
@@ -331,6 +337,7 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         mKeyboardView.setVisibility(View.GONE);
         mEmojiTabStripView.setVisibility(View.GONE);
         mSuggestionStripView.setVisibility(View.GONE);
+        mStripContainer.setVisibility(View.VISIBLE);
         mClipboardStripScrollView.post(() -> mClipboardStripScrollView.fullScroll(HorizontalScrollView.FOCUS_RIGHT));
         mClipboardStripScrollView.setVisibility(View.VISIBLE);
         mEmojiPalettesView.setVisibility(View.GONE);
@@ -624,6 +631,7 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         mClipboardStripView = mCurrentInputView.findViewById(R.id.clipboard_strip);
         mClipboardStripScrollView = mCurrentInputView.findViewById(R.id.clipboard_strip_scroll_view);
         mSuggestionStripView = mCurrentInputView.findViewById(R.id.suggestion_strip_view);
+        mStripContainer = mCurrentInputView.findViewById(R.id.strip_container);
 
         return mCurrentInputView;
     }

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -44,6 +44,7 @@ import helium314.keyboard.latin.utils.ResourceUtils;
 import helium314.keyboard.latin.utils.RunInLocaleKt;
 import helium314.keyboard.latin.utils.StatsUtils;
 import helium314.keyboard.latin.utils.SubtypeSettingsKt;
+import helium314.keyboard.latin.utils.ToolbarMode;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -153,6 +154,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_AUTO_SHOW_TOOLBAR = "auto_show_toolbar";
     public static final String PREF_AUTO_HIDE_TOOLBAR = "auto_hide_toolbar";
     public static final String PREF_CLIPBOARD_TOOLBAR_KEYS = "clipboard_toolbar_keys";
+    public static final String PREF_TOOLBAR_MODE = "toolbar_mode";
 
     // Emoji
     public static final String PREF_EMOJI_RECENT_KEYS = "emoji_recent_keys";
@@ -362,6 +364,15 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
 
     public static int readDefaultClipboardHistoryRetentionTime(final Resources res) {
         return res.getInteger(R.integer.config_clipboard_history_retention_time);
+    }
+
+    public static ToolbarMode readToolbarMode(final SharedPreferences prefs) {
+        return switch (prefs.getString(PREF_TOOLBAR_MODE, "toolbar_and_suggestions_mode")) {
+            case "hidden_mode" -> ToolbarMode.HIDDEN;
+            case "toolbar_keys_mode" -> ToolbarMode.TOOLBAR_KEYS;
+            case "suggestion_strip_mode" -> ToolbarMode.SUGGESTION_STRIP;
+            default -> ToolbarMode.EXPANDABLE;
+        };
     }
 
     public static int readHorizontalSpaceSwipe(final SharedPreferences prefs) {

--- a/app/src/main/java/helium314/keyboard/latin/settings/ToolbarSettingsFragment.kt
+++ b/app/src/main/java/helium314/keyboard/latin/settings/ToolbarSettingsFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import androidx.preference.Preference
 import helium314.keyboard.keyboard.KeyboardSwitcher
 import helium314.keyboard.latin.R
+import helium314.keyboard.latin.utils.ToolbarMode
 import helium314.keyboard.latin.utils.defaultClipboardToolbarPref
 import helium314.keyboard.latin.utils.defaultPinnedToolbarPref
 import helium314.keyboard.latin.utils.defaultToolbarPref
@@ -42,6 +43,7 @@ class ToolbarSettingsFragment : SubScreenFragment() {
                 ) { getToolbarIconByName(it, requireContext()) }
                 true
             }
+        refreshEnabledSettings()
     }
 
     override fun onPause() {
@@ -55,7 +57,20 @@ class ToolbarSettingsFragment : SubScreenFragment() {
         if (key == null) return
         when (key) {
             Settings.PREF_TOOLBAR_KEYS, Settings.PREF_CLIPBOARD_TOOLBAR_KEYS, Settings.PREF_PINNED_TOOLBAR_KEYS,
-            Settings.PREF_QUICK_PIN_TOOLBAR_KEYS -> reloadKeyboard = true
+            Settings.PREF_QUICK_PIN_TOOLBAR_KEYS, Settings.PREF_TOOLBAR_MODE -> reloadKeyboard = true
         }
+        refreshEnabledSettings()
+    }
+
+    private fun refreshEnabledSettings() {
+        val toolbarMode = Settings.readToolbarMode(sharedPreferences)
+        setPreferenceVisible(Settings.PREF_TOOLBAR_KEYS,
+            toolbarMode == ToolbarMode.TOOLBAR_KEYS || toolbarMode == ToolbarMode.EXPANDABLE)
+        setPreferenceVisible(Settings.PREF_PINNED_TOOLBAR_KEYS,
+            toolbarMode == ToolbarMode.SUGGESTION_STRIP || toolbarMode == ToolbarMode.EXPANDABLE)
+        setPreferenceVisible(Settings.PREF_QUICK_PIN_TOOLBAR_KEYS, toolbarMode == ToolbarMode.EXPANDABLE)
+        setPreferenceVisible(Settings.PREF_AUTO_SHOW_TOOLBAR, toolbarMode == ToolbarMode.EXPANDABLE)
+        setPreferenceVisible(Settings.PREF_AUTO_HIDE_TOOLBAR, toolbarMode == ToolbarMode.EXPANDABLE)
+        setPreferenceVisible(Settings.PREF_VARIABLE_TOOLBAR_DIRECTION, toolbarMode != ToolbarMode.HIDDEN)
     }
 }

--- a/app/src/main/java/helium314/keyboard/latin/utils/ToolbarUtils.kt
+++ b/app/src/main/java/helium314/keyboard/latin/utils/ToolbarUtils.kt
@@ -112,6 +112,10 @@ enum class ToolbarKey {
     FULL_LEFT, FULL_RIGHT, INCOGNITO, AUTOCORRECT, CLEAR_CLIPBOARD, CLOSE_HISTORY
 }
 
+enum class ToolbarMode {
+    HIDDEN, TOOLBAR_KEYS, SUGGESTION_STRIP, EXPANDABLE
+}
+
 val toolbarKeyStrings: Set<String> = entries.mapTo(HashSet()) { it.toString().lowercase(Locale.US) }
 
 val defaultToolbarPref = entries.filterNot { it == CLOSE_HISTORY }.joinToString(";") {

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -128,4 +128,16 @@
         <item>@string/switch_language</item>
         <item>@string/action_none</item>
     </string-array>
+    <string-array name="toolbar_mode_values">
+        <item>hidden_mode</item>
+        <item>toolbar_keys_mode</item>
+        <item>suggestion_strip_mode</item>
+        <item>expandable_toolbar_mode</item>
+    </string-array>
+    <string-array name="toolbar_mode_entries">
+        <item>@string/hidden_mode</item>
+        <item>@string/toolbar_keys_mode</item>
+        <item>@string/suggestion_strip_mode</item>
+        <item>@string/expandable_toolbar_mode</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -231,6 +231,16 @@
     <string name="popup_keys_language_priority" tools:keep="@string/popup_keys_language_priority">Language (priority)</string>
     <string name="popup_keys_layout" tools:keep="@string/popup_keys_layout">Layout</string>
     <string name="popup_keys_symbols" tools:keep="@string/popup_keys_symbols">Symbols</string>
+    <!-- Title of the setting to set the toolbar mode -->
+    <string name="toolbar_mode">Toolbar mode</string>
+    <!-- Option to set the toolbar mode to hidden -->
+    <string name="hidden_mode">Hidden</string>
+    <!-- Option to set the toolbar mode to show the toolbar keys only -->
+    <string name="toolbar_keys_mode">Toolbar keys</string>
+    <!-- Option to set the toolbar mode to show the suggestions strip only -->
+    <string name="suggestion_strip_mode">Suggestion strip</string>
+    <!-- Option to set the toolbar mode to show an expandable toolbar -->
+    <string name="expandable_toolbar_mode">Expandable toolbar</string>
     <!-- Title of the setting to set toolbar keys -->
     <string name="toolbar_keys">Select toolbar keys</string>
     <!-- Names of the toolbar keys-->

--- a/app/src/main/res/xml/prefs_screen_toolbar.xml
+++ b/app/src/main/res/xml/prefs_screen_toolbar.xml
@@ -6,8 +6,19 @@
 -->
 <PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:latin="http://schemas.android.com/apk/res-auto"
     android:title="@string/settings_screen_toolbar"
     android:key="screen_toolbar">
+
+    <ListPreference
+        android:defaultValue="expandable_toolbar_mode"
+        android:entries="@array/toolbar_mode_entries"
+        android:entryValues="@array/toolbar_mode_values"
+        android:key="toolbar_mode"
+        android:persistent="true"
+        android:summary="%s"
+        android:title="@string/toolbar_mode"
+        latin:singleLineTitle="false" />
 
     <Preference
         android:key="toolbar_keys"


### PR DESCRIPTION
I added a list preference to the new toolbar section that allows one to select one of the following toolbar modes:

1) Toolbar keys -> shows only the selected toolbar keys. Hides the expand toolbar key*
2) Suggestion strip -> shows only the suggestion strip & pinned keys. Hides the expand toolbar key*
3) Expandable toolbar -> Allows to switch between (2) and (3) with the expand toolbar key (current behavior, default)

(*) When incognito mode is on, the expand toolbar key will still be shown with the incognito icon but it won't allow expanding/collapsing the toolbar

I also tried to reduce activity in the SuggestionStripView class depending on the selected mode.

Should fix #732 

I tried to also make the toolbar hidden but got stuck due to [this issue](https://github.com/Helium314/HeliBoard/issues/374#issuecomment-1912285154).
It seems that the keyboard height of the emoji & clipboard views that does not take into account the (hidden) strip container.