### PR TITLE
fix phantom space after double quotes

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
@@ -1112,17 +1112,14 @@ public final class InputLogic {
                 mConnection.commitCodePoint(codePoint);
             }
         } else {
-            if ((SpaceState.PHANTOM == inputTransaction.getMSpaceState()
-                    && settingsValues.isUsuallyFollowedBySpace(codePoint))
-                    || (Constants.CODE_DOUBLE_QUOTE == codePoint
-                            && isInsideDoubleQuoteOrAfterDigit)) {
+            if (SpaceState.PHANTOM == inputTransaction.getMSpaceState()
+                    && settingsValues.isUsuallyFollowedBySpace(codePoint)) {
                 // If we are in phantom space state, and the user presses a separator, we want to
                 // stay in phantom space state so that the next keypress has a chance to add the
                 // space. For example, if I type "Good dat", pick "day" from the suggestion strip
                 // then insert a comma and go on to typing the next word, I want the space to be
                 // inserted automatically before the next word, the same way it is when I don't
-                // input the comma. A double quote behaves like it's usually followed by space if
-                // we're inside a double quote.
+                // input the comma.
                 // The case is a little different if the separator is a space stripper. Such a
                 // separator does not normally need a space on the right (that's the difference
                 // between swappers and strippers), so we should not stay in phantom space state if
@@ -1134,9 +1131,13 @@ public final class InputLogic {
                 // enabled the setting and was not composing a word. The latter avoids setting
                 // phantom space state when typing decimal numbers, with the drawback of not
                 // setting phantom space state after ending a sentence with a non-word.
+                // A double quote behaves like it's usually followed by space if we're inside
+                // a double quote.
                 if (wasComposingWord
                         && settingsValues.mAutospaceAfterPunctuationEnabled
-                        && settingsValues.isUsuallyFollowedBySpace(codePoint)) {
+                        && (settingsValues.isUsuallyFollowedBySpace(codePoint)
+                        || (Constants.CODE_DOUBLE_QUOTE == codePoint
+                        && isInsideDoubleQuoteOrAfterDigit))) {
                     mSpaceState = SpaceState.PHANTOM;
             }
 

--- a/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
@@ -1113,19 +1113,19 @@ public final class InputLogic {
             }
         } else {
             if (SpaceState.PHANTOM == inputTransaction.getMSpaceState()
-                    && settingsValues.isUsuallyFollowedBySpace(codePoint)) {
+                    && (settingsValues.isUsuallyFollowedBySpace(codePoint) || isInsideDoubleQuoteOrAfterDigit)) {
                 // If we are in phantom space state, and the user presses a separator, we want to
                 // stay in phantom space state so that the next keypress has a chance to add the
                 // space. For example, if I type "Good dat", pick "day" from the suggestion strip
                 // then insert a comma and go on to typing the next word, I want the space to be
                 // inserted automatically before the next word, the same way it is when I don't
-                // input the comma.
+                // input the comma. Also when closing a quote the phantom state should be preserved.
                 // The case is a little different if the separator is a space stripper. Such a
                 // separator does not normally need a space on the right (that's the difference
                 // between swappers and strippers), so we should not stay in phantom space state if
                 // the separator is a stripper. Hence the additional test above.
                 mSpaceState = SpaceState.PHANTOM;
-            } else
+            } else {
                 // mSpaceState is still SpaceState.NONE, but some characters should typically
                 // be followed by space. Set phantom space state for such characters if the user
                 // enabled the setting and was not composing a word. The latter avoids setting
@@ -1135,10 +1135,9 @@ public final class InputLogic {
                 // a double quote.
                 if (wasComposingWord
                         && settingsValues.mAutospaceAfterPunctuationEnabled
-                        && (settingsValues.isUsuallyFollowedBySpace(codePoint)
-                        || (Constants.CODE_DOUBLE_QUOTE == codePoint
-                        && isInsideDoubleQuoteOrAfterDigit))) {
+                        && (settingsValues.isUsuallyFollowedBySpace(codePoint) || isInsideDoubleQuoteOrAfterDigit)) {
                     mSpaceState = SpaceState.PHANTOM;
+                }
             }
 
             mConnection.commitCodePoint(codePoint);

--- a/app/src/test/java/helium314/keyboard/latin/InputLogicTest.kt
+++ b/app/src/test/java/helium314/keyboard/latin/InputLogicTest.kt
@@ -545,8 +545,50 @@ class InputLogicTest {
         assertEquals("hello ", text)
     }
 
+    @Test fun `no weird space inside multi-"`() {
+        reset()
+        chainInput("\"\"\"")
+        assertEquals("\"\"\"", text)
+
+        reset()
+        DeviceProtectedUtils.getSharedPreferences(latinIME).edit { putBoolean(Settings.PREF_AUTOSPACE_AFTER_PUNCTUATION, true) }
+        chainInput("\"\"\"")
+        assertEquals("\"\"\"", text)
+    }
+
+    @Test fun `autospace still happens after "`() {
+        reset()
+        DeviceProtectedUtils.getSharedPreferences(latinIME).edit { putBoolean(Settings.PREF_AUTOSPACE_AFTER_PUNCTUATION, true) }
+        chainInput("\"hello\"you")
+        assertEquals("\"hello\" you", text)
+    }
+
+    @Test fun `autospace still happens after " if next word is in quotes`() {
+        reset()
+        DeviceProtectedUtils.getSharedPreferences(latinIME).edit { putBoolean(Settings.PREF_AUTOSPACE_AFTER_PUNCTUATION, true) }
+        chainInput("\"hello\"\"you\"")
+        assertEquals("\"hello\" \"you\"", text)
+    }
+
+    @Test fun `autospace propagates over "`() {
+        reset()
+        input('"')
+        pickSuggestion("hello")
+        assertEquals(spaceState, SpaceState.PHANTOM) // picking a suggestion sets phantom space state
+        chainInput("\"you")
+        assertEquals("\"hello\" you", text)
+    }
+
+    @Test fun `autospace still happens after " if nex word is in " and after comma`() {
+        reset()
+        DeviceProtectedUtils.getSharedPreferences(latinIME).edit { putBoolean(Settings.PREF_AUTOSPACE_AFTER_PUNCTUATION, true) }
+        chainInput("\"hello\",\"you\"")
+        assertEquals("\"hello\", \"you\"", text)
+    }
+
     @Test fun `autospace in json editor`() {
         reset()
+        DeviceProtectedUtils.getSharedPreferences(latinIME).edit { putBoolean(Settings.PREF_AUTOSPACE_AFTER_PUNCTUATION, true) }
         chainInput("{\"label\":\"")
         assertEquals("{\"label\": \"", text)
         input('c')


### PR DESCRIPTION
When typing a closing double quote `"` and not composing a word, a phantom space should not be applied to the typed text.
Moreover, it should be applied only if the "auto space after punctuation" setting is enabled since a double quote is a punctuation. 
fixes #840