### PR TITLE
enable emoji toolbar key

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/utils/ToolbarUtils.kt
+++ b/app/src/main/java/helium314/keyboard/latin/utils/ToolbarUtils.kt
@@ -59,6 +59,7 @@ fun getCodeForToolbarKey(key: ToolbarKey) = when (key) {
     SELECT_WORD -> KeyCode.CLIPBOARD_SELECT_WORD
     CLEAR_CLIPBOARD -> KeyCode.CLIPBOARD_CLEAR_HISTORY
     CLOSE_HISTORY -> KeyCode.ALPHA
+    EMOJI -> KeyCode.EMOJI
 }
 
 fun getCodeForToolbarKeyLongClick(key: ToolbarKey) = when (key) {
@@ -95,6 +96,7 @@ fun getStyleableIconId(key: ToolbarKey) = when (key) {
     FULL_RIGHT -> R.styleable.Keyboard_iconFullRight
     SELECT_WORD -> R.styleable.Keyboard_iconSelectWord
     CLOSE_HISTORY -> R.styleable.Keyboard_iconClose
+    EMOJI -> R.styleable.Keyboard_iconEmojiNormalKey
 }
 
 fun getToolbarIconByName(name: String, context: Context): Drawable? {
@@ -109,14 +111,14 @@ fun getToolbarIconByName(name: String, context: Context): Drawable? {
 // names need to be aligned with resources strings (using lowercase of key.name)
 enum class ToolbarKey {
     VOICE, CLIPBOARD, UNDO, REDO, SETTINGS, SELECT_ALL, SELECT_WORD, COPY, CUT, ONE_HANDED, LEFT, RIGHT, UP, DOWN,
-    FULL_LEFT, FULL_RIGHT, INCOGNITO, AUTOCORRECT, CLEAR_CLIPBOARD, CLOSE_HISTORY
+    FULL_LEFT, FULL_RIGHT, INCOGNITO, AUTOCORRECT, CLEAR_CLIPBOARD, CLOSE_HISTORY, EMOJI
 }
 
 val toolbarKeyStrings: Set<String> = entries.mapTo(HashSet()) { it.toString().lowercase(Locale.US) }
 
 val defaultToolbarPref = entries.filterNot { it == CLOSE_HISTORY }.joinToString(";") {
     when (it) {
-        INCOGNITO, AUTOCORRECT, UP, DOWN, ONE_HANDED, FULL_LEFT, FULL_RIGHT, CUT, CLEAR_CLIPBOARD -> "${it.name},false"
+        INCOGNITO, AUTOCORRECT, UP, DOWN, ONE_HANDED, FULL_LEFT, FULL_RIGHT, CUT, CLEAR_CLIPBOARD, EMOJI -> "${it.name},false"
         else -> "${it.name},true"
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -252,6 +252,7 @@
     <string name="undo" tools:keep="@string/undo">Undo</string>
     <string name="redo" tools:keep="@string/redo">Redo</string>
     <string name="close_history" tools:keep="@string/close_history">Close clipboard history</string>
+    <string name="emoji" tools:keep="@string/emoji">Emoji</string>
     <!-- Title of the setting to set clipboard toolbar keys -->
     <string name="clipboard_toolbar_keys">Select clipboard toolbar keys</string>
     <!-- Title of the setting to set pinned toolbar keys -->


### PR DESCRIPTION
I think this addition should help making the keyboard a bit more familiar as many keyboards with a functional toolbar also have an emoji toolbar key.

The icon and keycode already exist, so they should only be enabled as a toolbar key.

fixes #837