### PR TITLE
Fix erroneous keyswipes

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -120,6 +120,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
     private long mStartTime;
     private boolean mInHorizontalSwipe = false;
     private boolean mInVerticalSwipe = false;
+    private static boolean sInKeySwipe = false;
 
     // true if keyboard layout has been changed.
     private boolean mKeyboardLayoutHasBeenChanged;
@@ -638,7 +639,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         // A gesture should start only from a non-modifier key. Note that the gesture detection is
         // disabled when the key is repeating.
         mIsDetectingGesture = (mKeyboard != null) && mKeyboard.mId.isAlphabetKeyboard()
-                && key != null && !key.isModifier() && !mKeySwipeAllowed;
+                && key != null && !key.isModifier() && !mKeySwipeAllowed && !sInKeySwipe;
         if (mIsDetectingGesture) {
             mBatchInputArbiter.addDownEventPoint(x, y, eventTime,
                     sTypingTimeRecorder.getLastLetterTypingTime(), getActivePointerTrackerCount());
@@ -931,6 +932,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
 
         // todo (later): move key swipe stuff to KeyboardActionListener (and finally extend it)
         if (mKeySwipeAllowed) {
+            sInKeySwipe = true;
             onKeySwipe(oldKey.getCode(), x, y, eventTime);
             return;
         }
@@ -1030,6 +1032,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         if (mInHorizontalSwipe || mInVerticalSwipe) {
             mInHorizontalSwipe = false;
             mInVerticalSwipe = false;
+            sInKeySwipe = false;
             return;
         }
 

--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -142,7 +142,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
     // true if dragging finger is allowed.
     private boolean mIsAllowedDraggingFinger;
     // true if a keyswipe gesture is enabled and allowed.
-    private boolean mKeySwipeAllowed;
+    private boolean mKeySwipeAllowed = false;
 
     private final BatchInputArbiter mBatchInputArbiter;
     private final GestureStrokeDrawingPoints mGestureStrokeDrawingPoints;

--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -120,7 +120,6 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
     private long mStartTime;
     private boolean mInHorizontalSwipe = false;
     private boolean mInVerticalSwipe = false;
-    private static boolean sInKeySwipe = false;
 
     // true if keyboard layout has been changed.
     private boolean mKeyboardLayoutHasBeenChanged;
@@ -639,7 +638,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         // A gesture should start only from a non-modifier key. Note that the gesture detection is
         // disabled when the key is repeating.
         mIsDetectingGesture = (mKeyboard != null) && mKeyboard.mId.isAlphabetKeyboard()
-                && key != null && !key.isModifier() && !mKeySwipeAllowed && !sInKeySwipe;
+                && key != null && !key.isModifier() && !mKeySwipeAllowed;
         if (mIsDetectingGesture) {
             mBatchInputArbiter.addDownEventPoint(x, y, eventTime,
                     sTypingTimeRecorder.getLastLetterTypingTime(), getActivePointerTrackerCount());
@@ -932,7 +931,6 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
 
         // todo (later): move key swipe stuff to KeyboardActionListener (and finally extend it)
         if (mKeySwipeAllowed) {
-            sInKeySwipe = true;
             onKeySwipe(oldKey.getCode(), x, y, eventTime);
             return;
         }
@@ -1032,7 +1030,6 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         if (mInHorizontalSwipe || mInVerticalSwipe) {
             mInHorizontalSwipe = false;
             mInVerticalSwipe = false;
-            sInKeySwipe = false;
             return;
         }
 

--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -877,7 +877,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
 
     private boolean keySwipe(final int code, final int x, final int y, final long eventTime) {
         final SettingsValues sv = Settings.getInstance().getCurrent();
-        final int fastTypingTimeout = 3 * sv.mKeyLongpressTimeout / 4;
+        final int fastTypingTimeout = 2 * sv.mKeyLongpressTimeout / 3;
         // we don't want keyswipes to start immediately if the user is fast-typing,
         // see https://github.com/openboard-team/openboard/issues/411
         if (System.currentTimeMillis() < mStartTime + fastTypingTimeout && sTypingTimeRecorder.isInFastTyping(eventTime))

--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -933,7 +933,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
     private void onMoveEventInternal(final int x, final int y, final long eventTime) {
         final Key oldKey = mCurrentKey;
 
-        // todo (later): extend key swipe stuff
+        // todo (later): move key swipe stuff to KeyboardActionListener (and finally extend it)
         if (mKeySwipeAllowed && keySwipe(oldKey.getCode(), x, y, eventTime))
             return;
 

--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -130,7 +130,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
 
     // the popup keys panel currently being shown. equals null if no panel is active.
     private PopupKeysPanel mPopupKeysPanel;
-    private boolean mDidShowPopupKeysPanel = false;
+    private boolean mDidShowPopupKeys = false;
 
     private static final int MULTIPLIER_FOR_LONG_PRESS_TIMEOUT_IN_SLIDING_INPUT = 3;
     // true if this pointer is in the dragging finger mode.
@@ -915,7 +915,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         final Key oldKey = mCurrentKey;
 
         // todo (later): extend key swipe stuff
-        if (!mIsInSlidingKeyInput && !mDidShowPopupKeysPanel && oldKey != null
+        if (!mIsInSlidingKeyInput && !mDidShowPopupKeys && oldKey != null
                 && keySwipe(oldKey.getCode(), x, y)) return;
 
         final Key newKey = onMoveKey(x, y);
@@ -998,7 +998,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
             sListener.onUpWithDeletePointerActive();
         }
 
-        mDidShowPopupKeysPanel = false;
+        mDidShowPopupKeys = false;
         if (isShowingPopupKeysPanel()) {
             if (!mIsTrackingForActionDisabled) {
                 final int translatedX = mPopupKeysPanel.translateX(x);
@@ -1103,7 +1103,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         final int translatedY = popupKeysPanel.translateY(mLastY);
         popupKeysPanel.onDownEvent(translatedX, translatedY, mPointerId, SystemClock.uptimeMillis());
         mPopupKeysPanel = popupKeysPanel;
-        mDidShowPopupKeysPanel = true;
+        mDidShowPopupKeys = true;
     }
 
     private void cancelKeyTracking() {

--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -667,7 +667,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         mIsAllowedDraggingFinger = sParams.mKeySelectionByDraggingFinger
                 || (key != null && key.isModifier())
                 || mKeyDetector.alwaysAllowsKeySelectionByDraggingFinger();
-        mKeySwipeAllowed = key != null && isSwiper(key.getCode());
+        mKeySwipeAllowed = key != null && isSwiper(key.getCode()) && !sInGesture;
         mKeyboardLayoutHasBeenChanged = false;
         mIsTrackingForActionDisabled = false;
         resetKeySelectionByDraggingFinger();

--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -902,7 +902,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
 
             // Horizontal movement
             int stepsX = dX / sPointerStep;
-            if (stepsX != 0 && !mInVerticalSwipe) {
+            if (stepsX != 0 && !mInVerticalSwipe && sv.mSpaceSwipeHorizontal != KeyboardActionListener.SWIPE_NO_ACTION) {
                 if (!mInHorizontalSwipe) {
                     sTimerProxy.cancelKeyTimersOf(this);
                     mInHorizontalSwipe = true;

--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -915,8 +915,8 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         final Key oldKey = mCurrentKey;
 
         // todo (later): extend key swipe stuff
-        if (!mIsInSlidingKeyInput && !mDidShowPopupKeys && oldKey != null
-                && keySwipe(oldKey.getCode(), x, y)) return;
+        if (!mIsInSlidingKeyInput && !mDidShowPopupKeys && mCurrentRepeatingKeyCode == Constants.NOT_A_CODE
+                && oldKey != null && keySwipe(oldKey.getCode(), x, y)) return;
 
         final Key newKey = onMoveKey(x, y);
         final int lastX = mLastX;

--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -668,7 +668,10 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         mIsAllowedDraggingFinger = sParams.mKeySelectionByDraggingFinger
                 || (key != null && key.isModifier())
                 || mKeyDetector.alwaysAllowsKeySelectionByDraggingFinger();
-        mKeySwipeAllowed = key != null && isSwiper(key.getCode()) && !sInGesture;
+        if (key != null && isSwiper(key.getCode()) && !sInGesture) {
+            mKeySwipeAllowed = true;
+            sInKeySwipe = true;
+        }
         mKeyboardLayoutHasBeenChanged = false;
         mIsTrackingForActionDisabled = false;
         resetKeySelectionByDraggingFinger();
@@ -719,7 +722,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
 
     private void onGestureMoveEvent(final int x, final int y, final long eventTime,
             final boolean isMajorEvent, final Key key) {
-        if (!mIsDetectingGesture) {
+        if (!mIsDetectingGesture || sInKeySwipe) {
             return;
         }
         final boolean onValidArea = mBatchInputArbiter.addMoveEventPoint(
@@ -932,7 +935,6 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
 
         // todo (later): move key swipe stuff to KeyboardActionListener (and finally extend it)
         if (mKeySwipeAllowed) {
-            sInKeySwipe = true;
             onKeySwipe(oldKey.getCode(), x, y, eventTime);
             return;
         }
@@ -1031,10 +1033,12 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
 
         if (mKeySwipeAllowed) {
             mKeySwipeAllowed = false;
-            mInHorizontalSwipe = false;
-            mInVerticalSwipe = false;
             sInKeySwipe = false;
-            return;
+            if (mInHorizontalSwipe || mInVerticalSwipe) {
+                mInHorizontalSwipe = false;
+                mInVerticalSwipe = false;
+                return;
+            }
         }
 
         if (sInGesture) {

--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -875,14 +875,13 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         }
     }
 
-    private boolean keySwipe(final Key key, final int x, final int y, final long eventTime) {
+    private boolean keySwipe(final int code, final int x, final int y, final long eventTime) {
         final SettingsValues sv = Settings.getInstance().getCurrent();
         final int fastTypingTimeout = 3 * sv.mKeyLongpressTimeout / 4;
         // we don't want keyswipes to start immediately if the user is fast-typing,
         // see https://github.com/openboard-team/openboard/issues/411
         if (System.currentTimeMillis() < mStartTime + fastTypingTimeout && sTypingTimeRecorder.isInFastTyping(eventTime))
             return true;
-        final int code = key.getCode();
         if (code == Constants.CODE_SPACE) {
             int dX = x - mStartX;
             int dY = y - mStartY;
@@ -935,7 +934,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         final Key oldKey = mCurrentKey;
 
         // todo (later): extend key swipe stuff
-        if (mKeySwipeAllowed && keySwipe(oldKey, x, y, eventTime))
+        if (mKeySwipeAllowed && keySwipe(oldKey.getCode(), x, y, eventTime))
             return;
 
         final Key newKey = onMoveKey(x, y);

--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -892,8 +892,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
 
             // Vertical movement
             int stepsY = dY / sPointerStep;
-            if (stepsY != 0 && abs(dX) < abs(dY) && !mInHorizontalSwipe
-                    && sv.mSpaceSwipeVertical != KeyboardActionListener.SWIPE_NO_ACTION) {
+            if (stepsY != 0 && abs(dX) < abs(dY) && !mInHorizontalSwipe) {
                 if (!mInVerticalSwipe) {
                     sTimerProxy.cancelKeyTimersOf(this);
                     mInVerticalSwipe = true;
@@ -906,8 +905,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
 
             // Horizontal movement
             int stepsX = dX / sPointerStep;
-            if (stepsX != 0 && !mInVerticalSwipe
-                    && sv.mSpaceSwipeHorizontal != KeyboardActionListener.SWIPE_NO_ACTION) {
+            if (stepsX != 0 && !mInVerticalSwipe) {
                 if (!mInHorizontalSwipe) {
                     sTimerProxy.cancelKeyTimersOf(this);
                     mInHorizontalSwipe = true;

--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -143,6 +143,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
     private boolean mIsAllowedDraggingFinger;
     // true if a keyswipe gesture is enabled and warranted.
     private boolean mKeySwipeAllowed = false;
+    private static boolean sInKeySwipe = false;
 
     private final BatchInputArbiter mBatchInputArbiter;
     private final GestureStrokeDrawingPoints mGestureStrokeDrawingPoints;
@@ -638,7 +639,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         // A gesture should start only from a non-modifier key. Note that the gesture detection is
         // disabled when the key is repeating.
         mIsDetectingGesture = (mKeyboard != null) && mKeyboard.mId.isAlphabetKeyboard()
-                && key != null && !key.isModifier() && !mKeySwipeAllowed;
+                && key != null && !key.isModifier() && !mKeySwipeAllowed && !sInKeySwipe;
         if (mIsDetectingGesture) {
             mBatchInputArbiter.addDownEventPoint(x, y, eventTime,
                     sTypingTimeRecorder.getLastLetterTypingTime(), getActivePointerTrackerCount());
@@ -931,6 +932,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
 
         // todo (later): move key swipe stuff to KeyboardActionListener (and finally extend it)
         if (mKeySwipeAllowed) {
+            sInKeySwipe = true;
             onKeySwipe(oldKey.getCode(), x, y, eventTime);
             return;
         }
@@ -1027,9 +1029,11 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
             return;
         }
 
-        if (mInHorizontalSwipe || mInVerticalSwipe) {
+        if (mKeySwipeAllowed) {
+            mKeySwipeAllowed = false;
             mInHorizontalSwipe = false;
             mInVerticalSwipe = false;
+            sInKeySwipe = false;
             return;
         }
 
@@ -1116,7 +1120,10 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         final int translatedY = popupKeysPanel.translateY(mLastY);
         popupKeysPanel.onDownEvent(translatedX, translatedY, mPointerId, SystemClock.uptimeMillis());
         mPopupKeysPanel = popupKeysPanel;
-        mKeySwipeAllowed = false;
+        if (mKeySwipeAllowed) {
+            mKeySwipeAllowed = false;
+            sInKeySwipe = false;
+        }
     }
 
     private void cancelKeyTracking() {
@@ -1242,7 +1249,10 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
             return;
         }
         mCurrentRepeatingKeyCode = code;
-        mKeySwipeAllowed = false;
+        if (mKeySwipeAllowed) {
+            mKeySwipeAllowed = false;
+            sInKeySwipe = false;
+        }
         mIsDetectingGesture = false;
         final int nextRepeatCount = repeatCount + 1;
         startKeyRepeatTimer(nextRepeatCount);

--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -891,7 +891,10 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
             int stepsY = dY / sPointerStep;
             if (stepsY != 0 && abs(dX) < abs(dY) && !mInHorizontalSwipe
                     && sv.mSpaceSwipeVertical != KeyboardActionListener.SWIPE_NO_ACTION) {
-                mInVerticalSwipe = true;
+                if (!mInVerticalSwipe) {
+                    sTimerProxy.cancelKeyTimersOf(this);
+                    mInVerticalSwipe = true;
+                }
                 if (sListener.onVerticalSpaceSwipe(stepsY)) {
                     mStartY += stepsY * sPointerStep;
                 }
@@ -901,7 +904,10 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
             // Horizontal movement
             int stepsX = dX / sPointerStep;
             if (stepsX != 0 && !mInVerticalSwipe) {
-                mInHorizontalSwipe = true;
+                if (!mInHorizontalSwipe) {
+                    sTimerProxy.cancelKeyTimersOf(this);
+                    mInHorizontalSwipe = true;
+                }
                 if (sListener.onHorizontalSpaceSwipe(stepsX)) {
                     mStartX += stepsX * sPointerStep;
                 }
@@ -913,8 +919,10 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
             // Delete slider
             int steps = (x - mStartX) / sPointerStep;
             if (abs(steps) > 2 || (mInHorizontalSwipe && steps != 0)) {
-                sTimerProxy.cancelKeyTimersOf(this);
-                mInHorizontalSwipe = true;
+                if (!mInHorizontalSwipe) {
+                    sTimerProxy.cancelKeyTimersOf(this);
+                    mInHorizontalSwipe = true;
+                }
                 mStartX += steps * sPointerStep;
                 sListener.onMoveDeletePointer(steps);
             }
@@ -1068,9 +1076,6 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
     public void onLongPressed() {
         sTimerProxy.cancelLongPressTimersOf(this);
         if (isShowingPopupKeysPanel()) {
-            return;
-        }
-        if(mInHorizontalSwipe || mInVerticalSwipe) {
             return;
         }
         final Key key = getKey();

--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -141,7 +141,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
 
     // true if dragging finger is allowed.
     private boolean mIsAllowedDraggingFinger;
-    // true if key swipes are allowed.
+    // true if a keyswipe gesture is enabled and allowed.
     private boolean mKeySwipeAllowed;
 
     private final BatchInputArbiter mBatchInputArbiter;

--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -638,7 +638,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         // A gesture should start only from a non-modifier key. Note that the gesture detection is
         // disabled when the key is repeating.
         mIsDetectingGesture = (mKeyboard != null) && mKeyboard.mId.isAlphabetKeyboard()
-                && key != null && !key.isModifier();
+                && key != null && !key.isModifier() && !mKeySwipeAllowed;
         if (mIsDetectingGesture) {
             mBatchInputArbiter.addDownEventPoint(x, y, eventTime,
                     sTypingTimeRecorder.getLastLetterTypingTime(), getActivePointerTrackerCount());

--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -141,7 +141,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
 
     // true if dragging finger is allowed.
     private boolean mIsAllowedDraggingFinger;
-    // true if a keyswipe gesture is enabled and allowed.
+    // true if a keyswipe gesture is enabled and warranted.
     private boolean mKeySwipeAllowed = false;
 
     private final BatchInputArbiter mBatchInputArbiter;

--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -886,8 +886,9 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
             }
 
             // Horizontal movement
+            if (sv.mSpaceSwipeHorizontal == KeyboardActionListener.SWIPE_NO_ACTION) return false;
             int stepsX = dX / sPointerStep;
-            if (stepsX != 0 && !mInVerticalSwipe && sv.mSpaceSwipeHorizontal != KeyboardActionListener.SWIPE_NO_ACTION) {
+            if (stepsX != 0 && !mInVerticalSwipe) {
                 mInHorizontalSwipe = true;
                 if (sListener.onHorizontalSpaceSwipe(stepsX)) {
                     mStartX += stepsX * sPointerStep;


### PR DESCRIPTION
This patch fixes the bug where keyswipe gestures can be triggered if they're hovered when browsing popup-keys panels.

It also keeps the space bar from preventing alternative move-events if it doesn't have a swipe gesture enabled. Examples: a space-swipe for the other direction, popup-panel browsing, and gesture typing (so same behavior as keys like return, punctuations, and AOSP space).

This fix opens the door to possibly having keys with pop-ups *and* swipe gestures in the future. I also moved keyswipe handling into a separate function to help with that to-do comment. Let me know if I misinterpreted "and finally extend it" when re-writing the comment.

Something I'm curious about: should this `mDidShowPopupKeys` be set to false if `onCancelEvent()` is called? I notice that method doesn't really adjust any of the fields.

Fixes #918