### PR TITLE
Remove separate longpress timeout for shift (caps lock)

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -1174,8 +1174,11 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
 
     private int getLongPressTimeout(final int code) {
         final int longpressTimeout = Settings.getInstance().getCurrent().mKeyLongpressTimeout;
-        if (mIsInSlidingKeyInput) {
-            // We use longer timeout for sliding finger input started from the modifier key.
+        if (code == KeyCode.SHIFT || code == KeyCode.SYMBOL_ALPHA) {
+            // We use slightly longer timeout for shift-lock and the numpad long-press.
+            return longpressTimeout * 3 / 2;
+        } else if (mIsInSlidingKeyInput) {
+            // We use longer timeout for sliding finger input started from a modifier key.
             return longpressTimeout * MULTIPLIER_FOR_LONG_PRESS_TIMEOUT_IN_SLIDING_INPUT;
         }
         return longpressTimeout;

--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -56,7 +56,6 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         public final int mSuppressKeyPreviewAfterBatchInputDuration;
         public final int mKeyRepeatStartTimeout;
         public final int mKeyRepeatInterval;
-        public final int mLongPressShiftLockTimeout;
 
         public PointerTrackerParams(final TypedArray mainKeyboardViewAttr) {
             mKeySelectionByDraggingFinger = mainKeyboardViewAttr.getBoolean(
@@ -71,8 +70,6 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
                     R.styleable.MainKeyboardView_keyRepeatStartTimeout, 0);
             mKeyRepeatInterval = mainKeyboardViewAttr.getInt(
                     R.styleable.MainKeyboardView_keyRepeatInterval, 0);
-            mLongPressShiftLockTimeout = mainKeyboardViewAttr.getInt(
-                    R.styleable.MainKeyboardView_longPressShiftLockTimeout, 0);
         }
     }
 
@@ -1176,9 +1173,6 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
     }
 
     private int getLongPressTimeout(final int code) {
-        if (code == KeyCode.SHIFT) {
-            return sParams.mLongPressShiftLockTimeout;
-        }
         final int longpressTimeout = Settings.getInstance().getCurrent().mKeyLongpressTimeout;
         if (mIsInSlidingKeyInput) {
             // We use longer timeout for sliding finger input started from the modifier key.

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -94,8 +94,6 @@
         <attr name="keyRepeatStartTimeout" format="integer" />
         <!-- Key repeat interval in millisecond. -->
         <attr name="keyRepeatInterval" format="integer" />
-        <!-- Long press timeout of shift key to shift lock in millisecond. -->
-        <attr name="longPressShiftLockTimeout" format="integer" />
         <!-- Ignore special key timeout while typing in millisecond. -->
         <attr name="ignoreAltCodeKeyTimeout" format="integer" />
         <!-- Background resource for key press feedback.-->

--- a/app/src/main/res/values/config-common.xml
+++ b/app/src/main/res/values/config-common.xml
@@ -37,9 +37,6 @@
     <integer name="config_accessibility_long_press_key_timeout">3000</integer>
     <integer name="config_max_popup_keys_column">5</integer>
 
-    <!-- Long pressing shift will invoke caps-lock if > 0, never invoke caps-lock if == 0 -->
-    <integer name="config_longpress_shift_lock_timeout">1200</integer>
-
     <!-- Sliding key input preview parameters -->
     <dimen name="config_sliding_key_input_preview_width">8.0dp</dimen>
     <!-- Percentages of sliding key input preview body and shadow, in proportion to the width.

--- a/app/src/main/res/values/themes-common.xml
+++ b/app/src/main/res/values/themes-common.xml
@@ -61,7 +61,6 @@
         <item name="slidingKeyInputPreviewShadowRatio">@integer/config_sliding_key_input_preview_shadow_ratio</item>
         <item name="keyRepeatStartTimeout">@integer/config_key_repeat_start_timeout</item>
         <item name="keyRepeatInterval">@integer/config_key_repeat_interval</item>
-        <item name="longPressShiftLockTimeout">@integer/config_longpress_shift_lock_timeout</item>
         <item name="ignoreAltCodeKeyTimeout">@integer/config_ignore_alt_code_key_timeout</item>
         <item name="popupKeysKeyboardLayout">@layout/popup_keys_keyboard</item>
         <item name="showPopupKeysKeyboardAtTouchedPoint">@bool/config_show_popup_keys_keyboard_at_touched_point</item>


### PR DESCRIPTION
This patch removes the separate longpress duration attribute for the shift key altogether. I believe it's not useful, as I opine in the issue below. The only thing I'm side-eyeing is that `"config_accessibility_long_press_key_timeout"`. I don't know the circumstances in which that value (3000) is used, but it's the only possible case where that hard-coded shift-lock duration is less than the general one.

Maybe there should be a special accessibility case where the shift-lock duration is set to 1200? I don't know.

Resolves #923