### PR TITLE
Small changes to toolbar long-clicks

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Does not use internet permission, and thus is 100% offline.
 
 ## Hidden Functionality
 Features that may go unnoticed, and further potentially useful information
-* Long-pressing toolbar keys results in additional functionality: clipboard -> paste, move left/right -> word left/right, move up/down -> page up/down, word left/right -> line start/end, page up/down -> page start/end, copy -> copy all, select word -> select all, undo <-> redo
+* Long-pressing toolbar keys results in additional functionality: clipboard -> paste, move left/right -> word left/right, move up/down -> page up/down, word left/right -> line start/end, page up/down -> page start/end, copy -> cut, select word <-> select all, undo <-> redo
 * Long-press the Comma-key to access Clipboard View, Emoji View, One-handed Mode, Settings, or Switch Language:
   * Emoji View and Language Switch will disappear if you have the corresponding key enabled;
   * For some layouts it\'s not the Comma-key, but the key at the same position (e.g. it\'s `q` for Dvorak layout).

--- a/app/src/main/java/helium314/keyboard/latin/utils/ToolbarUtils.kt
+++ b/app/src/main/java/helium314/keyboard/latin/utils/ToolbarUtils.kt
@@ -71,7 +71,7 @@ fun getCodeForToolbarKeyLongClick(key: ToolbarKey) = when (key) {
     REDO -> KeyCode.UNDO
     SELECT_ALL -> KeyCode.CLIPBOARD_SELECT_WORD
     SELECT_WORD -> KeyCode.CLIPBOARD_SELECT_ALL
-    COPY -> KeyCode.CLIPBOARD_COPY_ALL
+    COPY -> KeyCode.CLIPBOARD_CUT
     PASTE -> KeyCode.CLIPBOARD
     LEFT -> KeyCode.WORD_LEFT
     RIGHT -> KeyCode.WORD_RIGHT

--- a/app/src/main/java/helium314/keyboard/latin/utils/ToolbarUtils.kt
+++ b/app/src/main/java/helium314/keyboard/latin/utils/ToolbarUtils.kt
@@ -69,6 +69,7 @@ fun getCodeForToolbarKeyLongClick(key: ToolbarKey) = when (key) {
     CLIPBOARD -> KeyCode.CLIPBOARD_PASTE
     UNDO -> KeyCode.REDO
     REDO -> KeyCode.UNDO
+    SELECT_ALL -> KeyCode.CLIPBOARD_SELECT_WORD
     SELECT_WORD -> KeyCode.CLIPBOARD_SELECT_ALL
     COPY -> KeyCode.CLIPBOARD_COPY_ALL
     PASTE -> KeyCode.CLIPBOARD

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -803,8 +803,8 @@ New dictionary:
 \n\t• move up/down &amp;#65515; page up/down &lt;br&gt;
 \n\t• word left/right &amp;#65515; line start/end &lt;br&gt;
 \n\t• page up/down &amp;#65515; page start/end &lt;br&gt;
-\n\t• copy &amp;#65515; copy all &lt;br&gt;
-\n\t• select word &amp;#65515; select all &lt;br&gt;
+\n\t• copy &amp;#65515; cut &lt;br&gt;
+\n\t• select word &amp;#8596; select all &lt;br&gt;
 \n\t• undo &amp;#8596; redo &lt;br&gt; &lt;br&gt;
 \n► Long-pressing keys in the suggestion strip toolbar pins them to the suggestion strip. &lt;br&gt; &lt;br&gt;
 \n► Long-press the Comma-key to access Clipboard View, Emoji View, One-handed Mode, Settings, or Switch Language: &lt;br&gt;


### PR DESCRIPTION
This patch closes #958 by making "select all" perform the "select word" action when long-clicked in the toolbar. I think the mirroring makes sense.

I've also made another change: long-clicking 'copy' now cuts selected text instead of copying all surrounding text. The reasoning is that if I have text selected, I usually want to do the former more often than the latter. If I do want to copy the surrounding text, I just de-select and hit the copy key normally, which copies all text. Let me know how you feel about this change.

Speaking of, would you like me to implement de-selection for the select-word key? Currently, it just does nothing once text is selected. I believe the implementation is simple as replacing the "do nothing" comment with "`set selection: (currentEnd, currentEnd)`"