### PR TITLE
De-select text with selection keys

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/LatinIME.java
+++ b/app/src/main/java/helium314/keyboard/latin/LatinIME.java
@@ -1761,7 +1761,7 @@ public class LatinIME extends InputMethodService implements
                     return;
                 break;
             case KeyCode.ARROW_RIGHT, KeyCode.ARROW_DOWN, KeyCode.WORD_RIGHT, KeyCode.PAGE_DOWN:
-                if (!mInputLogic.mConnection.canForwardDeleteCharacters())
+                if (mInputLogic.mConnection.noTextAfterCursor())
                     return;
                 break;
             }

--- a/app/src/main/java/helium314/keyboard/latin/RichInputConnection.java
+++ b/app/src/main/java/helium314/keyboard/latin/RichInputConnection.java
@@ -363,9 +363,9 @@ public final class RichInputConnection implements PrivateCommandPerformer {
         return mExpectedSelStart > 0;
     }
 
-    public boolean canForwardDeleteCharacters() {
+    public boolean noTextAfterCursor() {
         final CharSequence after = getTextAfterCursor(1, 0);
-        return !TextUtils.isEmpty(after);
+        return TextUtils.isEmpty(after);
     }
 
     /**
@@ -728,12 +728,17 @@ public final class RichInputConnection implements PrivateCommandPerformer {
 
     public void selectAll() {
         if (!isConnected()) return;
-        mIC.performContextMenuAction(android.R.id.selectAll);
+        if (mExpectedSelStart != mExpectedSelEnd && mExpectedSelStart == 0 && noTextAfterCursor()) { // all text already selected
+            mIC.setSelection(mExpectedSelEnd, mExpectedSelEnd);
+        } else mIC.performContextMenuAction(android.R.id.selectAll);
     }
 
     public void selectWord(final SpacingAndPunctuations spacingAndPunctuations, final String script) {
         if (!isConnected()) return;
-        if (mExpectedSelStart != mExpectedSelEnd) return; // already something selected
+        if (mExpectedSelStart != mExpectedSelEnd) { // already something selected
+            mIC.setSelection(mExpectedSelEnd, mExpectedSelEnd);
+            return;
+        }
         final TextRange range = getWordRangeAtCursor(spacingAndPunctuations, script);
         if (range == null) return;
         mIC.setSelection(mExpectedSelStart - range.getNumberOfCharsInWordBeforeCursor(), mExpectedSelStart + range.getNumberOfCharsInWordAfterCursor());


### PR DESCRIPTION
This patch enables the selection keys to de-select text if a selection already exists. Select-all tries to only deselect in cases where all text has been selected (you can still select-all if you just have a partial selection).

There are material icons for deselection, but I've not tried to implement selection-based icon changes for the toolbar or main keyboard. This could be tried later if a "text selection mode" is implemented.