### PR TITLE
Change dialog & drop down menu backgrounds color for Android12+

### DIFF
--- a/app/src/main/res/values-v31/colors.xml
+++ b/app/src/main/res/values-v31/colors.xml
@@ -24,7 +24,7 @@
     <color name="setup_text_action">@android:color/system_accent1_700</color>
     <color name="setup_step_action_text_pressed">@android:color/system_accent1_500</color>
     <color name="action_bar_color">@android:color/system_accent1_50</color>
-    <color name="sliding_items_background">@android:color/system_accent1_50</color>
+    <color name="sliding_items_background">@android:color/system_neutral2_50</color>
     <color name="dialog_background">@android:color/system_neutral2_50</color>
     <color name="drop_down_menu_background">@android:color/system_neutral2_50</color>
 </resources>

--- a/app/src/main/res/values-v31/colors.xml
+++ b/app/src/main/res/values-v31/colors.xml
@@ -25,6 +25,6 @@
     <color name="setup_step_action_text_pressed">@android:color/system_accent1_500</color>
     <color name="action_bar_color">@android:color/system_accent1_50</color>
     <color name="sliding_items_background">@android:color/system_accent1_50</color>
-    <color name="dialog_background">@android:color/system_accent1_50</color>
-    <color name="drop_down_menu_background">@android:color/system_accent1_10</color>
+    <color name="dialog_background">@android:color/system_neutral2_50</color>
+    <color name="drop_down_menu_background">@android:color/system_neutral2_50</color>
 </resources>


### PR DESCRIPTION
When I proposed commit 9fb59ed, I made a mistake in the choice of dynamic background color for dialog boxes and the drop-down menu for Android 12+.

We're now closer to the default material colors.

<details>
<summary><b>See screenshots</b></summary>
<br>

| Before | After |
| :------: | :----: |
| <img width=200 src="https://github.com/user-attachments/assets/dcf76095-331a-4b53-91ae-0ba6f66782da"> | <img width=200 src="https://github.com/user-attachments/assets/d8fc12c1-4206-4456-b6b4-069deca80b13"> |

</details>

To know:
- Only the light theme of the device is affected;
- With this change, the contrast between the text and the background of dialog boxes (for editing layouts, for example) is much clearer.