### PR TITLE
Update rounded icons for rounded style - Fix #694

### DIFF
--- a/app/src/main/res/drawable/ic_autocorrect_rounded.xml
+++ b/app/src/main/res/drawable/ic_autocorrect_rounded.xml
@@ -1,5 +1,6 @@
 <!--
-    icon available in Android Studio
+    SPDX-FileCopyrightText: Material Design Authors / Google LLC
+    modified
     SPDX-License-Identifier: Apache-2.0
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
@@ -8,5 +9,5 @@
     android:viewportWidth="960"
     android:viewportHeight="960">
     <path android:fillColor="#FFF"
-        android:pathData="M200,760v-80h560v80L200,760ZM276,600 L440,160h80l164,440h-76l-38,-112L392,488l-40,112h-76ZM414,424h132l-64,-182h-4l-64,182Z"/>
+        android:pathData="M240,760Q223,760 211.5,748.5Q200,737 200,720Q200,703 211.5,691.5Q223,680 240,680L720,680Q737,680 748.5,691.5Q760,703 760,720Q760,737 748.5,748.5Q737,760 720,760L240,760ZM294,552L431,184Q435,173 444.5,166.5Q454,160 466,160L494,160Q506,160 515.5,166.5Q525,173 529,184L666,553Q672,570 662,585Q652,600 634,600Q623,600 613.5,593.5Q604,587 600,576L570,488L392,488L360,577Q356,588 347,594Q338,600 327,600L327,600Q308,600 297.5,584.5Q287,569 294,552ZM414,424L546,424L482,242L478,242L414,424Z"/>
 </vector>

--- a/app/src/main/res/drawable/ic_close_rounded.xml
+++ b/app/src/main/res/drawable/ic_close_rounded.xml
@@ -1,0 +1,13 @@
+<!--
+    SPDX-FileCopyrightText: Material Design Authors / Google LLC
+    modified
+    SPDX-License-Identifier: Apache-2.0
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="960"
+    android:viewportWidth="960"  >
+    <path android:fillColor="#FFF"
+        android:pathData="M480,536L284,732Q273,743 256,743Q239,743 228,732Q217,721 217,704Q217,687 228,676L424,480L228,284Q217,273 217,256Q217,239 228,228Q239,217 256,217Q273,217 284,228L480,424L676,228Q687,217 704,217Q721,217 732,228Q743,239 743,256Q743,273 732,284L536,480L732,676Q743,687 743,704Q743,721 732,732Q721,743 704,743Q687,743 676,732L480,536Z"/>
+</vector>

--- a/app/src/main/res/drawable/sym_keyboard_cut_rounded.xml
+++ b/app/src/main/res/drawable/sym_keyboard_cut_rounded.xml
@@ -1,0 +1,13 @@
+<!--
+    SPDX-FileCopyrightText: Material Design Authors / Google LLC
+    modified
+    SPDX-License-Identifier: Apache-2.0
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="960"
+    android:viewportWidth="960">
+    <path android:fillColor="#FFF"
+        android:pathData="m480 560l-94 94q8 15 11 32q3 17 3 34q0 66-47 113q-47 47-113 47q-66 0-113-47q-47-47-47-113q0-66 47-113q47-47 113-47q17 0 34 3q17 3 32 11l 94-94l-94-94q-15 8-32 11q-17 3-34 3q-66 0-113-47q-47-47-47-113q0-66 47-113q47-47 113-47q66 0 113 47q47 47 47 113q0 17-3 34q-3 17-11 32l 438 438q27 27 12 62q-15 35-53 35q-11 0-22-5q-11-5-19-13l-263-263zm120-120l-80-80l 223-223q8-8 19-13q11-5 22-5q38 0 53 35q15 35-13 62l-223 223zm-360-120q33 0 57-24q24-24 24-57q0-33-24-57q-24-24-57-24q-33 0-57 24q-24 24-24 57q0 33 24 57q24 24 57 24zm240 180q8 0 14-6q6-6 6-14q0-8-6-14q-6-6-14-6q-8 0-14 6q-6 6-6 14q0 8 6 14q6 6 14 6zm-240 300q33 0 57-24q24-24 24-57q0-33-24-57q-24-24-57-24q-33 0-57 24q-24 24-24 57q0 33 24 57q24 24 57 24z"/>
+</vector>

--- a/app/src/main/res/values/keyboard-icons-rounded.xml
+++ b/app/src/main/res/values/keyboard-icons-rounded.xml
@@ -34,7 +34,7 @@
         <item name="iconClipboardActionKey">@drawable/sym_keyboard_clipboard_rounded</item>
         <item name="iconClipboardNormalKey">@drawable/sym_keyboard_clipboard_rounded</item>
         <item name="iconCopyKey">@drawable/sym_keyboard_copy_rounded</item>
-        <item name="iconCutKey">@drawable/sym_keyboard_cut</item>
+        <item name="iconCutKey">@drawable/sym_keyboard_cut_rounded</item>
         <item name="iconPasteKey">@drawable/sym_keyboard_paste_rounded</item>
         <item name="iconClearClipboardKey">@drawable/sym_keyboard_clear_clipboard_rounded</item>
         <item name="iconStartOneHandedMode">@drawable/sym_keyboard_start_onehanded_rounded</item>
@@ -60,6 +60,6 @@
         <item name="iconPageStart">@drawable/ic_page_start_rounded</item>
         <item name="iconPageEnd">@drawable/ic_page_end_rounded</item>
         <item name="iconSelectWord">@drawable/ic_select_rounded</item>
-        <item name="iconClose">@drawable/ic_close</item>
+        <item name="iconClose">@drawable/ic_close_rounded</item>
     </style>
 </resources>


### PR DESCRIPTION
Update rounded icons - Fix #694

It seems to me that you didn't want the rounded "close" icon, but I can't remember where; however, I can confirm that on larger screens, the difference is real and the appearance is more consistent with the other icons.