### PR TITLE
Debug minify

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,7 +34,7 @@ android {
             renderscriptDebuggable false
         }
         debug {
-            minifyEnabled true
+            minifyEnabled false
             jniDebuggable false
             applicationIdSuffix ".debug"
         }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,7 +57,7 @@ android {
     }
 
 
-    ndkVersion '26.2.11394342'
+    ndkVersion '27.0.12077973'
 
     packagingOptions {
         jniLibs {


### PR DESCRIPTION
Minify gets disabled automatically on debug builds. Also, update to latest NDK r27.