### PR TITLE
Triggering of haptic and audio feedback during cursor movement on spacebar swipe

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
@@ -188,6 +188,10 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
                 return true
             }
         }
+
+        //Maybe consider specifying some new KeyCode to prevent spamming of the default sound
+        latinIME.hapticAndAudioFeedback(KeyCode.NOT_SPECIFIED, 0)
+        
         if (inputLogic.moveCursorByAndReturnIfInsideComposingWord(moveSteps)) {
             // no need to finish input and restart suggestions if we're still in the word
             // this is a noticeable performance improvement


### PR DESCRIPTION
I added a line that triggers the default haptic and audio feedback when the cursor is getting moved by swiping over the spacebar.
If keypress sound is enabled the sound might get spammed a bit. 

The implementation works well for me like this but I didnt fully understand the method I modified so maybe this doesnt make sense in every case.

Issue 381 also requested this. 