### PR TITLE
Updated Line Breaks of Strings Due to Weblate Limitations

### DIFF
--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -196,17 +196,15 @@
     <string name="add_new_dictionary_ask_locale">%2$s এর \"%1$s\" অভিধান কোন ভাষার জন্য সংযুক্ত হবে?</string>
     <string name="button_select_language">ভাষা নির্বাচন</string>
     <string name="button_add_to_language">%s এ সংযুক্তি</string>
-    <string name="replace_dictionary_message">ব্যবহারকারী-যোগকৃত অভিধান \"%1$s\" প্রতিস্থাপন করতে নিশ্চিত?
-\n
-\nবর্তমান অভিধান:
-\n%2$s
-\n
-\nনতুন অভিধান:
-\n%3$s</string>
+    <string name="replace_dictionary_message">ব্যবহারকারী-যোগকৃত অভিধান \"%1$s\" প্রতিস্থাপন করতে নিশ্চিত?\n
+বর্তমান অভিধান:
+%2$s\n
+নতুন অভিধান:
+%3$s"</string>
     <string name="replace_dictionary">"অভিধান প্রতিস্থাপন"</string>
     <string name="remove_dictionary_message">ব্যবহারকারী-সংযুক্ত অভিধান \"%s\" অপসারণ করতে নিশ্চিত?</string>
     <string name="no_dictionary_message">"অভিধান ব্যতীত কেবল পূর্বে সন্নিবেশিত শব্দের জন্য পরামর্শ পাওয়া যাবে।&lt;br&gt;
-\n        আপনি %1$s অভিধান ডাউনলোড করতে পারেন, অথবা \"%2$s\" এর জন্য অভিধান সরাসরি ডাউনলোড করা যায় কি না %3$s যাচাই করতে পারেন।"</string>
+        আপনি %1$s অভিধান ডাউনলোড করতে পারেন, অথবা \"%2$s\" এর জন্য অভিধান সরাসরি ডাউনলোড করা যায় কি না %3$s যাচাই করতে পারেন।"</string>
     <string name="no_dictionary_dont_show_again_button">পুনরায় প্রদর্শিত হবে না</string>
     <string name="add_dictionary">অভিধান যোগ করার জন্য নির্বাচন করুন। %s .dict ফরম্যাটে অভিধান ডাউনলোড করা যেতে পারে।</string>
     <string name="dictionary_file_wrong_script">ত্রুটি: এই কিবোর্ডের সাথে সামঞ্জস্যপূর্ণ স্ক্রিপ্ট নয়</string>


### PR DESCRIPTION
The existing line breaks (\n) were causing conflicts with Weblate during string updates in the repository. So, adjustments were needed in the main Bengali string file to match the English String.