### PR TITLE
Allow changing toolbar icon and codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Does not use internet permission, and thus is 100% offline.
   <li>Backup and restore your settings and learned word / history data</li>
 </ul>
 
-For more information about the app and features, please visit the [wiki](https://github.com/Helium314/HeliBoard/wiki)
+For FAQ and more information about the app and features, please visit the [wiki](https://github.com/Helium314/HeliBoard/wiki)
 
 # Contributing ❤
 

--- a/app/src/main/java/helium314/keyboard/keyboard/Key.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/Key.java
@@ -938,13 +938,12 @@ public class Key implements Comparable<Key> {
         final String iconName = getIconName();
         if (iconName == null) return false;
         // todo: other way of identifying the color?
-        //  if yes, NAME_CLIPBOARD_ACTION_KEY and NAME_CLIPBOARD_NORMAL_KEY could be merged
+        //  this should be done differently, as users can set any icon now
+        //  how is the background drawable selected? can we use the same way?
         return iconName.equals(KeyboardIconsSet.NAME_NEXT_KEY)
-                || iconName.equals(KeyboardIconsSet.NAME_PREVIOUS_KEY);
-        // todo: maybe need to undo the removal of those names
-        //  but actually this should be done differently, as users can set any icon now -> try make it work
-//                || iconName.equals(KeyboardIconsSet.NAME_CLIPBOARD_ACTION_KEY)
-//                || iconName.equals(KeyboardIconsSet.NAME_EMOJI_ACTION_KEY);
+                || iconName.equals(KeyboardIconsSet.NAME_PREVIOUS_KEY)
+                || iconName.equals("clipboard_action_key")
+                || iconName.equals("emoji_action_key");
     }
 
     public boolean hasFunctionalBackground() {

--- a/app/src/main/java/helium314/keyboard/keyboard/Key.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/Key.java
@@ -940,9 +940,11 @@ public class Key implements Comparable<Key> {
         // todo: other way of identifying the color?
         //  if yes, NAME_CLIPBOARD_ACTION_KEY and NAME_CLIPBOARD_NORMAL_KEY could be merged
         return iconName.equals(KeyboardIconsSet.NAME_NEXT_KEY)
-                || iconName.equals(KeyboardIconsSet.NAME_PREVIOUS_KEY)
-                || iconName.equals(KeyboardIconsSet.NAME_CLIPBOARD_ACTION_KEY)
-                || iconName.equals(KeyboardIconsSet.NAME_EMOJI_ACTION_KEY);
+                || iconName.equals(KeyboardIconsSet.NAME_PREVIOUS_KEY);
+        // todo: maybe need to undo the removal of those names
+        //  but actually this should be done differently, as users can set any icon now -> try make it work
+//                || iconName.equals(KeyboardIconsSet.NAME_CLIPBOARD_ACTION_KEY)
+//                || iconName.equals(KeyboardIconsSet.NAME_EMOJI_ACTION_KEY);
     }
 
     public boolean hasFunctionalBackground() {

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/KeyboardIconsSet.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/KeyboardIconsSet.kt
@@ -59,7 +59,6 @@ class KeyboardIconsSet private constructor() {
         const val NAME_SHIFT_KEY_SHIFTED = "shift_key_shifted"
         const val NAME_SHIFT_KEY_LOCKED = "shift_key_locked"
         const val NAME_DELETE_KEY = "delete_key"
-        const val NAME_SETTINGS_KEY = "settings_key"
         const val NAME_SPACE_KEY = "space_key"
         const val NAME_SPACE_KEY_FOR_NUMBER_LAYOUT = "space_key_for_number_layout"
         const val NAME_ENTER_KEY = "enter_key"
@@ -70,7 +69,6 @@ class KeyboardIconsSet private constructor() {
         const val NAME_DONE_KEY = "done_key"
         const val NAME_PREVIOUS_KEY = "previous_key"
         const val NAME_TAB_KEY = "tab_key"
-        const val NAME_INCOGNITO_KEY = "incognito_key"
         const val NAME_SHORTCUT_KEY_DISABLED = "shortcut_key_disabled"
         const val NAME_LANGUAGE_SWITCH_KEY = "language_switch_key"
         const val NAME_ZWNJ_KEY = "zwnj_key"
@@ -92,6 +90,8 @@ class KeyboardIconsSet private constructor() {
             "clipboard_action_key" to ToolbarKey.CLIPBOARD.name.lowercase(Locale.US),
             "clipboard_normal_key" to ToolbarKey.CLIPBOARD.name.lowercase(Locale.US),
             "cut_key" to ToolbarKey.CUT.name.lowercase(Locale.US),
+            "incognito_key" to ToolbarKey.INCOGNITO.name.lowercase(Locale.US),
+            "settings_key" to ToolbarKey.SETTINGS.name.lowercase(Locale.US),
         )
 
         // todo: incognito and force incognito should not be the same? or not the same as toolbar key?
@@ -100,7 +100,6 @@ class KeyboardIconsSet private constructor() {
             NAME_SHIFT_KEY_SHIFTED to           R.drawable.sym_keyboard_shifted_holo,
             NAME_SHIFT_KEY_LOCKED to            R.drawable.sym_keyboard_shift_lock_holo,
             NAME_DELETE_KEY to                  R.drawable.sym_keyboard_delete_holo,
-            NAME_SETTINGS_KEY to                R.drawable.sym_keyboard_settings_holo,
 //            NAME_SPACE_KEY to                   null,
             NAME_ENTER_KEY to                   R.drawable.sym_keyboard_return_holo,
 //            NAME_GO_KEY to                      null,
@@ -110,7 +109,6 @@ class KeyboardIconsSet private constructor() {
 //            NAME_NEXT_KEY to                    null,
 //            NAME_PREVIOUS_KEY to                null,
             NAME_TAB_KEY to                     R.drawable.sym_keyboard_tab_holo,
-            NAME_INCOGNITO_KEY to               R.drawable.sym_keyboard_incognito_holo,
             NAME_SPACE_KEY_FOR_NUMBER_LAYOUT to R.drawable.sym_keyboard_space_holo,
             NAME_SHORTCUT_KEY_DISABLED to       R.drawable.sym_keyboard_voice_off_holo,
             NAME_LANGUAGE_SWITCH_KEY to         R.drawable.sym_keyboard_language_switch,
@@ -163,7 +161,6 @@ class KeyboardIconsSet private constructor() {
             NAME_SHIFT_KEY_SHIFTED to           R.drawable.sym_keyboard_shift_lxx,
             NAME_SHIFT_KEY_LOCKED to            R.drawable.sym_keyboard_shift_lock_lxx,
             NAME_DELETE_KEY to                  R.drawable.sym_keyboard_delete_lxx,
-            NAME_SETTINGS_KEY to                R.drawable.sym_keyboard_settings_lxx,
 //            NAME_SPACE_KEY to                   null,
             NAME_ENTER_KEY to                   R.drawable.sym_keyboard_return_lxx,
             NAME_GO_KEY to                      R.drawable.sym_keyboard_go_lxx,
@@ -173,7 +170,6 @@ class KeyboardIconsSet private constructor() {
             NAME_NEXT_KEY to                    R.drawable.ic_arrow_right,
             NAME_PREVIOUS_KEY to                R.drawable.ic_arrow_left,
             NAME_TAB_KEY to                     R.drawable.sym_keyboard_tab_lxx,
-            NAME_INCOGNITO_KEY to               R.drawable.sym_keyboard_incognito_lxx,
             NAME_SPACE_KEY_FOR_NUMBER_LAYOUT to R.drawable.sym_keyboard_space_lxx,
             NAME_SHORTCUT_KEY_DISABLED to       R.drawable.sym_keyboard_voice_off_lxx,
             NAME_LANGUAGE_SWITCH_KEY to         R.drawable.sym_keyboard_language_switch_lxx,
@@ -226,7 +222,6 @@ class KeyboardIconsSet private constructor() {
             NAME_SHIFT_KEY_SHIFTED to           R.drawable.sym_keyboard_shift_rounded,
             NAME_SHIFT_KEY_LOCKED to            R.drawable.sym_keyboard_shift_lock_rounded,
             NAME_DELETE_KEY to                  R.drawable.sym_keyboard_delete_rounded,
-            NAME_SETTINGS_KEY to                R.drawable.sym_keyboard_settings_rounded,
 //            NAME_SPACE_KEY to                   null,
             NAME_ENTER_KEY to                   R.drawable.sym_keyboard_return_rounded,
             NAME_GO_KEY to                      R.drawable.sym_keyboard_go_rounded,
@@ -236,7 +231,6 @@ class KeyboardIconsSet private constructor() {
             NAME_NEXT_KEY to                    R.drawable.ic_arrow_right_rounded,
             NAME_PREVIOUS_KEY to                R.drawable.ic_arrow_left_rounded,
             NAME_TAB_KEY to                     R.drawable.sym_keyboard_tab_rounded,
-            NAME_INCOGNITO_KEY to               R.drawable.sym_keyboard_incognito_lxx,
             NAME_SPACE_KEY_FOR_NUMBER_LAYOUT to R.drawable.sym_keyboard_space_rounded,
             NAME_SHORTCUT_KEY_DISABLED to       R.drawable.sym_keyboard_voice_off_rounded,
             NAME_LANGUAGE_SWITCH_KEY to         R.drawable.sym_keyboard_language_switch_lxx,

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/KeyboardIconsSet.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/KeyboardIconsSet.kt
@@ -73,7 +73,6 @@ class KeyboardIconsSet private constructor() {
         const val NAME_LANGUAGE_SWITCH_KEY = "language_switch_key"
         const val NAME_ZWNJ_KEY = "zwnj_key"
         const val NAME_ZWJ_KEY = "zwj_key"
-        const val NAME_START_ONEHANDED_KEY = "start_onehanded_mode_key"
         const val NAME_STOP_ONEHANDED_KEY = "stop_onehanded_mode_key"
         const val NAME_SWITCH_ONEHANDED_KEY = "switch_onehanded_key"
         const val NAME_RESIZE_ONEHANDED_KEY = "resize_onehanded_key"
@@ -92,6 +91,7 @@ class KeyboardIconsSet private constructor() {
             "cut_key" to ToolbarKey.CUT.name.lowercase(Locale.US),
             "incognito_key" to ToolbarKey.INCOGNITO.name.lowercase(Locale.US),
             "settings_key" to ToolbarKey.SETTINGS.name.lowercase(Locale.US),
+            "start_onehanded_mode_key" to ToolbarKey.ONE_HANDED.name.lowercase(Locale.US),
         )
 
         // todo: incognito and force incognito should not be the same? or not the same as toolbar key?
@@ -114,7 +114,6 @@ class KeyboardIconsSet private constructor() {
             NAME_LANGUAGE_SWITCH_KEY to         R.drawable.sym_keyboard_language_switch,
             NAME_ZWNJ_KEY to                    R.drawable.sym_keyboard_zwnj_holo,
             NAME_ZWJ_KEY to                     R.drawable.sym_keyboard_zwj_holo,
-            NAME_START_ONEHANDED_KEY to         R.drawable.sym_keyboard_start_onehanded_holo,
             NAME_STOP_ONEHANDED_KEY to          R.drawable.sym_keyboard_stop_onehanded_holo,
             NAME_SWITCH_ONEHANDED_KEY to        R.drawable.ic_arrow_left,
             NAME_RESIZE_ONEHANDED_KEY to        R.drawable.ic_arrow_horizontal,
@@ -175,7 +174,6 @@ class KeyboardIconsSet private constructor() {
             NAME_LANGUAGE_SWITCH_KEY to         R.drawable.sym_keyboard_language_switch_lxx,
             NAME_ZWNJ_KEY to                    R.drawable.sym_keyboard_zwnj_lxx,
             NAME_ZWJ_KEY to                     R.drawable.sym_keyboard_zwj_lxx,
-            NAME_START_ONEHANDED_KEY to         R.drawable.sym_keyboard_start_onehanded_lxx,
             NAME_STOP_ONEHANDED_KEY to          R.drawable.sym_keyboard_stop_onehanded_lxx,
             NAME_SWITCH_ONEHANDED_KEY to        R.drawable.ic_arrow_left,
             NAME_RESIZE_ONEHANDED_KEY to        R.drawable.ic_arrow_horizontal,
@@ -236,7 +234,6 @@ class KeyboardIconsSet private constructor() {
             NAME_LANGUAGE_SWITCH_KEY to         R.drawable.sym_keyboard_language_switch_lxx,
             NAME_ZWNJ_KEY to                    R.drawable.sym_keyboard_zwnj_lxx,
             NAME_ZWJ_KEY to                     R.drawable.sym_keyboard_zwj_lxx,
-            NAME_START_ONEHANDED_KEY to         R.drawable.sym_keyboard_start_onehanded_rounded,
             NAME_STOP_ONEHANDED_KEY to          R.drawable.sym_keyboard_stop_onehanded_rounded,
             NAME_SWITCH_ONEHANDED_KEY to        R.drawable.ic_arrow_left_rounded,
             NAME_RESIZE_ONEHANDED_KEY to        R.drawable.ic_arrow_horizontal_rounded,

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/KeyboardIconsSet.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/KeyboardIconsSet.kt
@@ -42,10 +42,14 @@ class KeyboardIconsSet private constructor() {
         }
     }
 
-    fun getIconDrawable(name: String?): Drawable? = iconsByName[name?.lowercase(Locale.US)]
+    fun getIconDrawable(name: String?): Drawable? = name?.lowercase(Locale.US)?.let {
+        iconsByName[it] ?: iconsByName[alternativeNames[it]]
+    }
+
     /** gets drawable from resources, with mutate (might be necessary to avoid coloring issues...) */
-    fun getNewDrawable(name: String?, context: Context): Drawable? =
-        iconIds[name?.lowercase(Locale.US)]?.let { ContextCompat.getDrawable(context, it)?.mutate() }
+    fun getNewDrawable(name: String?, context: Context): Drawable? = name?.lowercase(Locale.US)?.let { name ->
+        (iconIds[name] ?: iconIds[alternativeNames[name]])?.let { ContextCompat.getDrawable(context, it)?.mutate() }
+    }
 
     // sometimes there are 2 names for the same icon for historic reasons,
     // and removing needs to be handled with care to not break custom themes
@@ -68,24 +72,28 @@ class KeyboardIconsSet private constructor() {
         const val NAME_DONE_KEY = "done_key"
         const val NAME_PREVIOUS_KEY = "previous_key"
         const val NAME_TAB_KEY = "tab_key"
-        const val NAME_SHORTCUT_KEY = "shortcut_key"
         const val NAME_INCOGNITO_KEY = "incognito_key"
         const val NAME_SHORTCUT_KEY_DISABLED = "shortcut_key_disabled"
         const val NAME_LANGUAGE_SWITCH_KEY = "language_switch_key"
         const val NAME_ZWNJ_KEY = "zwnj_key"
         const val NAME_ZWJ_KEY = "zwj_key"
-        const val NAME_EMOJI_ACTION_KEY = "emoji_action_key"
-        const val NAME_EMOJI_NORMAL_KEY = "emoji_normal_key"
-        const val NAME_CLIPBOARD_ACTION_KEY = "clipboard_action_key"
-        const val NAME_CLIPBOARD_NORMAL_KEY = "clipboard_normal_key"
-        const val NAME_CLEAR_CLIPBOARD_KEY = "clear_clipboard_key"
-        const val NAME_CUT_KEY = "cut_key"
         const val NAME_START_ONEHANDED_KEY = "start_onehanded_mode_key"
         const val NAME_STOP_ONEHANDED_KEY = "stop_onehanded_mode_key"
         const val NAME_SWITCH_ONEHANDED_KEY = "switch_onehanded_key"
         const val NAME_RESIZE_ONEHANDED_KEY = "resize_onehanded_key"
         const val NAME_TOOLBAR_KEY = "toolbar_key"
         const val NAME_BIN = "bin"
+
+        // is use for historic reasons, and we can't just delete them because they might still be in use in user's layouts
+        private val alternativeNames = hashMapOf(
+            "clear_clipboard_key" to ToolbarKey.CLEAR_CLIPBOARD.name.lowercase(Locale.US),
+            "shortcut_key" to ToolbarKey.VOICE.name.lowercase(Locale.US),
+            "emoji_action_key" to ToolbarKey.EMOJI.name.lowercase(Locale.US),
+            "emoji_normal_key" to ToolbarKey.EMOJI.name.lowercase(Locale.US),
+            "clipboard_action_key" to ToolbarKey.CLIPBOARD.name.lowercase(Locale.US),
+            "clipboard_normal_key" to ToolbarKey.CLIPBOARD.name.lowercase(Locale.US),
+            "cut_key" to ToolbarKey.CUT.name.lowercase(Locale.US),
+        )
 
         private val keyboardIconsHolo by lazy { hashMapOf(
             NAME_SHIFT_KEY to                   R.drawable.sym_keyboard_shift_holo,
@@ -104,17 +112,10 @@ class KeyboardIconsSet private constructor() {
             NAME_TAB_KEY to                     R.drawable.sym_keyboard_tab_holo,
             NAME_INCOGNITO_KEY to               R.drawable.sym_keyboard_incognito_holo,
             NAME_SPACE_KEY_FOR_NUMBER_LAYOUT to R.drawable.sym_keyboard_space_holo,
-            NAME_SHORTCUT_KEY to                R.drawable.sym_keyboard_voice_holo,
             NAME_SHORTCUT_KEY_DISABLED to       R.drawable.sym_keyboard_voice_off_holo,
             NAME_LANGUAGE_SWITCH_KEY to         R.drawable.sym_keyboard_language_switch,
             NAME_ZWNJ_KEY to                    R.drawable.sym_keyboard_zwnj_holo,
             NAME_ZWJ_KEY to                     R.drawable.sym_keyboard_zwj_holo,
-            NAME_EMOJI_ACTION_KEY to            R.drawable.sym_keyboard_smiley_holo,
-            NAME_EMOJI_NORMAL_KEY to            R.drawable.sym_keyboard_smiley_holo,
-            NAME_CLIPBOARD_ACTION_KEY to        R.drawable.sym_keyboard_clipboard_holo,
-            NAME_CLIPBOARD_NORMAL_KEY to        R.drawable.sym_keyboard_clipboard_holo,
-            NAME_CLEAR_CLIPBOARD_KEY to         R.drawable.sym_keyboard_clear_clipboard_holo,
-            NAME_CUT_KEY to                     R.drawable.sym_keyboard_cut,
             NAME_START_ONEHANDED_KEY to         R.drawable.sym_keyboard_start_onehanded_holo,
             NAME_STOP_ONEHANDED_KEY to          R.drawable.sym_keyboard_stop_onehanded_holo,
             NAME_SWITCH_ONEHANDED_KEY to        R.drawable.ic_arrow_left,
@@ -174,17 +175,10 @@ class KeyboardIconsSet private constructor() {
             NAME_TAB_KEY to                     R.drawable.sym_keyboard_tab_lxx,
             NAME_INCOGNITO_KEY to               R.drawable.sym_keyboard_incognito_lxx,
             NAME_SPACE_KEY_FOR_NUMBER_LAYOUT to R.drawable.sym_keyboard_space_lxx,
-            NAME_SHORTCUT_KEY to                R.drawable.sym_keyboard_voice_lxx,
             NAME_SHORTCUT_KEY_DISABLED to       R.drawable.sym_keyboard_voice_off_lxx,
             NAME_LANGUAGE_SWITCH_KEY to         R.drawable.sym_keyboard_language_switch_lxx,
             NAME_ZWNJ_KEY to                    R.drawable.sym_keyboard_zwnj_lxx,
             NAME_ZWJ_KEY to                     R.drawable.sym_keyboard_zwj_lxx,
-            NAME_EMOJI_ACTION_KEY to            R.drawable.sym_keyboard_smiley_lxx,
-            NAME_EMOJI_NORMAL_KEY to            R.drawable.sym_keyboard_smiley_lxx,
-            NAME_CLIPBOARD_ACTION_KEY to        R.drawable.sym_keyboard_clipboard_lxx,
-            NAME_CLIPBOARD_NORMAL_KEY to        R.drawable.sym_keyboard_clipboard_lxx,
-            NAME_CLEAR_CLIPBOARD_KEY to         R.drawable.sym_keyboard_clear_clipboard_lxx,
-            NAME_CUT_KEY to                     R.drawable.sym_keyboard_cut,
             NAME_START_ONEHANDED_KEY to         R.drawable.sym_keyboard_start_onehanded_lxx,
             NAME_STOP_ONEHANDED_KEY to          R.drawable.sym_keyboard_stop_onehanded_lxx,
             NAME_SWITCH_ONEHANDED_KEY to        R.drawable.ic_arrow_left,
@@ -244,17 +238,10 @@ class KeyboardIconsSet private constructor() {
             NAME_TAB_KEY to                     R.drawable.sym_keyboard_tab_rounded,
             NAME_INCOGNITO_KEY to               R.drawable.sym_keyboard_incognito_lxx,
             NAME_SPACE_KEY_FOR_NUMBER_LAYOUT to R.drawable.sym_keyboard_space_rounded,
-            NAME_SHORTCUT_KEY to                R.drawable.sym_keyboard_voice_rounded,
             NAME_SHORTCUT_KEY_DISABLED to       R.drawable.sym_keyboard_voice_off_rounded,
             NAME_LANGUAGE_SWITCH_KEY to         R.drawable.sym_keyboard_language_switch_lxx,
             NAME_ZWNJ_KEY to                    R.drawable.sym_keyboard_zwnj_lxx,
             NAME_ZWJ_KEY to                     R.drawable.sym_keyboard_zwj_lxx,
-            NAME_EMOJI_ACTION_KEY to            R.drawable.sym_keyboard_smiley_rounded,
-            NAME_EMOJI_NORMAL_KEY to            R.drawable.sym_keyboard_smiley_rounded,
-            NAME_CLIPBOARD_ACTION_KEY to        R.drawable.sym_keyboard_clipboard_rounded,
-            NAME_CLIPBOARD_NORMAL_KEY to        R.drawable.sym_keyboard_clipboard_rounded,
-            NAME_CLEAR_CLIPBOARD_KEY to         R.drawable.sym_keyboard_clear_clipboard_rounded,
-            NAME_CUT_KEY to                     R.drawable.sym_keyboard_cut_rounded,
             NAME_START_ONEHANDED_KEY to         R.drawable.sym_keyboard_start_onehanded_rounded,
             NAME_STOP_ONEHANDED_KEY to          R.drawable.sym_keyboard_stop_onehanded_rounded,
             NAME_SWITCH_ONEHANDED_KEY to        R.drawable.ic_arrow_left_rounded,

--- a/app/src/main/java/helium314/keyboard/latin/Settings.kt
+++ b/app/src/main/java/helium314/keyboard/latin/Settings.kt
@@ -1,0 +1,16 @@
+package helium314.keyboard.latin
+
+import android.content.Context
+import android.content.SharedPreferences
+import helium314.keyboard.latin.settings.Settings
+import kotlinx.serialization.json.Json
+
+fun customIconNames(prefs: SharedPreferences) = runCatching {
+    Json.decodeFromString<Map<String, String>>(prefs.getString(Settings.PREF_CUSTOM_ICON_NAMES, "")!!)
+}.getOrElse { emptyMap() }
+
+fun customIconIds(context: Context, prefs: SharedPreferences) = customIconNames(prefs)
+    .mapNotNull { entry ->
+        val id = runCatching { context.resources.getIdentifier(entry.value, "drawable", context.packageName) }.getOrNull()
+        id?.let { entry.key to it }
+    }

--- a/app/src/main/java/helium314/keyboard/latin/settings/AppearanceSettingsFragment.kt
+++ b/app/src/main/java/helium314/keyboard/latin/settings/AppearanceSettingsFragment.kt
@@ -263,10 +263,10 @@ class AppearanceSettingsFragment : SubScreenFragment() {
 
             override fun onBindViewHolder(viewHolder: RecyclerView.ViewHolder, position: Int) {
                 val icon = ContextCompat.getDrawable(ctx, iconsList[position])?.mutate()
-                val iv = viewHolder.itemView as? ImageView
-                iv?.setImageDrawable(icon)
-                if (iconsList[position] == currentIconId) iv?.setColorFilter(R.color.accent)
-                else iv?.colorFilter = iconColorFilter
+                val imageView = viewHolder.itemView as? ImageView
+                imageView?.setImageDrawable(icon)
+                if (iconsList[position] == currentIconId) imageView?.setColorFilter(R.color.accent)
+                else imageView?.colorFilter = iconColorFilter
                 viewHolder.itemView.setOnClickListener { v ->
                     rv.forEach { (it as? ImageView)?.colorFilter = iconColorFilter }
                     (v as? ImageView)?.setColorFilter(R.color.accent)
@@ -277,7 +277,7 @@ class AppearanceSettingsFragment : SubScreenFragment() {
         rv.adapter = adapter
         val title = iconName.getStringResourceOrName("", ctx).takeUnless { it == iconName }
             ?: iconName.getStringResourceOrName("label_", ctx)
-        val b = AlertDialog.Builder(ctx)
+        val builder = AlertDialog.Builder(ctx)
             .setTitle(title)
             .setView(rv)
             .setPositiveButton(android.R.string.ok) { _, _ ->
@@ -291,7 +291,7 @@ class AppearanceSettingsFragment : SubScreenFragment() {
             }
             .setNegativeButton(android.R.string.cancel) { _, _ -> onClickCustomizeIcons() }
         if (customIconNames(sharedPreferences).contains(iconName))
-            b.setNeutralButton(R.string.button_default) { _, _ ->
+            builder.setNeutralButton(R.string.button_default) { _, _ ->
                 runCatching {
                     val icons2 = customIconNames(sharedPreferences).toMutableMap()
                     icons2.remove(iconName)
@@ -301,7 +301,7 @@ class AppearanceSettingsFragment : SubScreenFragment() {
                 onClickCustomizeIcons()
             }
 
-        b.show()
+        builder.show()
     }
 
     private fun onClickLoadImage(): Boolean {

--- a/app/src/main/java/helium314/keyboard/latin/settings/AppearanceSettingsFragment.kt
+++ b/app/src/main/java/helium314/keyboard/latin/settings/AppearanceSettingsFragment.kt
@@ -277,7 +277,7 @@ class AppearanceSettingsFragment : SubScreenFragment() {
         rv.adapter = adapter
         val title = iconName.getStringResourceOrName("", ctx).takeUnless { it == iconName }
             ?: iconName.getStringResourceOrName("label_", ctx)
-        AlertDialog.Builder(ctx)
+        val b = AlertDialog.Builder(ctx)
             .setTitle(title)
             .setView(rv)
             .setPositiveButton(android.R.string.ok) { _, _ ->
@@ -289,7 +289,9 @@ class AppearanceSettingsFragment : SubScreenFragment() {
                 }
                 onClickCustomizeIcons()
             }
-            .setNeutralButton(R.string.button_default) { _, _ ->
+            .setNegativeButton(android.R.string.cancel) { _, _ -> onClickCustomizeIcons() }
+        if (customIconNames(sharedPreferences).contains(iconName))
+            b.setNeutralButton(R.string.button_default) { _, _ ->
                 runCatching {
                     val icons2 = customIconNames(sharedPreferences).toMutableMap()
                     icons2.remove(iconName)
@@ -298,8 +300,8 @@ class AppearanceSettingsFragment : SubScreenFragment() {
                 }
                 onClickCustomizeIcons()
             }
-            .setNegativeButton(android.R.string.cancel) { _, _ -> onClickCustomizeIcons() }
-            .show()
+
+        b.show()
     }
 
     private fun onClickLoadImage(): Boolean {

--- a/app/src/main/java/helium314/keyboard/latin/settings/AppearanceSettingsFragment.kt
+++ b/app/src/main/java/helium314/keyboard/latin/settings/AppearanceSettingsFragment.kt
@@ -208,6 +208,7 @@ class AppearanceSettingsFragment : SubScreenFragment() {
             setPadding(padding, 3 * padding, padding, padding)
         }
         val d = AlertDialog.Builder(ctx)
+            .setTitle(R.string.customize_icons)
             .setView(ScrollView(context).apply { addView(ll) })
             .setPositiveButton(R.string.dialog_close, null)
             .create()
@@ -274,8 +275,10 @@ class AppearanceSettingsFragment : SubScreenFragment() {
             }
         }
         rv.adapter = adapter
+        val title = iconName.getStringResourceOrName("", ctx).takeUnless { it == iconName }
+            ?: iconName.getStringResourceOrName("label_", ctx)
         AlertDialog.Builder(ctx)
-            .setTitle("customize icon")
+            .setTitle(title)
             .setView(rv)
             .setPositiveButton(android.R.string.ok) { _, _ ->
                 runCatching {

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -52,6 +52,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
 
 public final class Settings implements SharedPreferences.OnSharedPreferenceChangeListener {
@@ -192,6 +193,8 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     // static cache for background images to avoid potentially slow reload on every settings reload
     private static Drawable sCachedBackgroundDay;
     private static Drawable sCachedBackgroundNight;
+    private Map<String, Integer> mCustomToolbarKeyCodes = null;
+    private Map<String, Integer> mCustomToolbarLongpressCodes = null;
 
     private static final Settings sInstance = new Settings();
 
@@ -239,6 +242,8 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
                 Log.w(TAG, "onSharedPreferenceChanged called before loadSettings.");
                 return;
             }
+            mCustomToolbarLongpressCodes = null;
+            mCustomToolbarKeyCodes = null;
             loadSettings(mContext, mSettingsValues.mLocale, mSettingsValues.mInputAttributes);
             StatsUtils.onLoadSettings(mSettingsValues);
         } finally {
@@ -713,10 +718,14 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     }
 
     public Integer getCustomToolbarKeyCode(ToolbarKey key) {
-        return ToolbarUtilsKt.readCustomKeyCodes(mPrefs).get(key.name());
+        if (mCustomToolbarKeyCodes == null)
+            mCustomToolbarKeyCodes = ToolbarUtilsKt.readCustomKeyCodes(mPrefs);
+        return mCustomToolbarKeyCodes.get(key.name());
     }
 
     public Integer getCustomToolbarLongpressCode(ToolbarKey key) {
-        return ToolbarUtilsKt.readCustomLongpressCodes(mPrefs).get(key.name());
+        if (mCustomToolbarLongpressCodes == null)
+            mCustomToolbarLongpressCodes = ToolbarUtilsKt.readCustomLongpressCodes(mPrefs);
+        return mCustomToolbarLongpressCodes.get(key.name());
     }
 }

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -81,7 +81,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_COLOR_BACKGROUND_SUFFIX = "background";
     public static final String PREF_AUTO_USER_COLOR_SUFFIX = "_auto";
     public static final String PREF_ALL_COLORS_SUFFIX = "all_colors";
-    public static final String PREF_TOOLBAR_CUSTOM_ICON_NAMES = "toolbar_custom_icon_names";
+    public static final String PREF_CUSTOM_ICON_NAMES = "custom_icon_names";
     public static final String PREF_TOOLBAR_CUSTOM_KEY_CODES = "toolbar_custom_key_codes";
     public static final String PREF_TOOLBAR_CUSTOM_LONGPRESS_CODES = "toolbar_custom_longpress_codes";
 

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -44,6 +44,8 @@ import helium314.keyboard.latin.utils.ResourceUtils;
 import helium314.keyboard.latin.utils.RunInLocaleKt;
 import helium314.keyboard.latin.utils.StatsUtils;
 import helium314.keyboard.latin.utils.SubtypeSettingsKt;
+import helium314.keyboard.latin.utils.ToolbarKey;
+import helium314.keyboard.latin.utils.ToolbarUtilsKt;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -79,7 +81,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_COLOR_BACKGROUND_SUFFIX = "background";
     public static final String PREF_AUTO_USER_COLOR_SUFFIX = "_auto";
     public static final String PREF_ALL_COLORS_SUFFIX = "all_colors";
-    public static final String PREF_TOOLBAR_CUSTOM_ICON_IDS = "toolbar_custom_icon_ids";
+    public static final String PREF_TOOLBAR_CUSTOM_ICON_NAMES = "toolbar_custom_icon_names";
     public static final String PREF_TOOLBAR_CUSTOM_KEY_CODES = "toolbar_custom_key_codes";
     public static final String PREF_TOOLBAR_CUSTOM_LONGPRESS_CODES = "toolbar_custom_longpress_codes";
 
@@ -708,5 +710,13 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
 
     public String readCustomCurrencyKey() {
         return mPrefs.getString(PREF_CUSTOM_CURRENCY_KEY, "");
+    }
+
+    public Integer getCustomToolbarKeyCode(ToolbarKey key) {
+        return ToolbarUtilsKt.readCustomKeyCodes(mPrefs).get(key.name());
+    }
+
+    public Integer getCustomToolbarLongpressCode(ToolbarKey key) {
+        return ToolbarUtilsKt.readCustomLongpressCodes(mPrefs).get(key.name());
     }
 }

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -79,6 +79,9 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_COLOR_BACKGROUND_SUFFIX = "background";
     public static final String PREF_AUTO_USER_COLOR_SUFFIX = "_auto";
     public static final String PREF_ALL_COLORS_SUFFIX = "all_colors";
+    public static final String PREF_TOOLBAR_CUSTOM_ICON_IDS = "toolbar_custom_icon_ids";
+    public static final String PREF_TOOLBAR_CUSTOM_KEY_CODES = "toolbar_custom_key_codes";
+    public static final String PREF_TOOLBAR_CUSTOM_LONGPRESS_CODES = "toolbar_custom_longpress_codes";
 
     public static final String PREF_AUTO_CAP = "auto_cap";
     public static final String PREF_VIBRATE_ON = "vibrate_on";

--- a/app/src/main/java/helium314/keyboard/latin/settings/ToolbarSettingsFragment.kt
+++ b/app/src/main/java/helium314/keyboard/latin/settings/ToolbarSettingsFragment.kt
@@ -10,6 +10,7 @@ import helium314.keyboard.latin.utils.defaultClipboardToolbarPref
 import helium314.keyboard.latin.utils.defaultPinnedToolbarPref
 import helium314.keyboard.latin.utils.defaultToolbarPref
 import helium314.keyboard.latin.utils.reorderDialog
+import helium314.keyboard.latin.utils.toolbarKeysCustomizer
 
 class ToolbarSettingsFragment : SubScreenFragment() {
     private var reloadKeyboard = false
@@ -42,6 +43,11 @@ class ToolbarSettingsFragment : SubScreenFragment() {
                     requireContext(), Settings.PREF_CLIPBOARD_TOOLBAR_KEYS, defaultClipboardToolbarPref,
                     R.string.clipboard_toolbar_keys
                 ) { iconsSet.getNewDrawable(it, requireContext()) }
+                true
+            }
+        findPreference<Preference>("customize_keys")?.onPreferenceClickListener =
+            Preference.OnPreferenceClickListener {
+                toolbarKeysCustomizer(requireContext())
                 true
             }
     }

--- a/app/src/main/java/helium314/keyboard/latin/settings/ToolbarSettingsFragment.kt
+++ b/app/src/main/java/helium314/keyboard/latin/settings/ToolbarSettingsFragment.kt
@@ -45,7 +45,7 @@ class ToolbarSettingsFragment : SubScreenFragment() {
                 ) { iconsSet.getNewDrawable(it, requireContext()) }
                 true
             }
-        findPreference<Preference>("customize_keys")?.onPreferenceClickListener =
+        findPreference<Preference>("customize_key_codes")?.onPreferenceClickListener =
             Preference.OnPreferenceClickListener {
                 toolbarKeysCustomizer(requireContext())
                 true

--- a/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.java
+++ b/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.java
@@ -182,7 +182,7 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
         mMoreSuggestionsSlidingDetector = new GestureDetector(context, mMoreSuggestionsSlidingListener);
 
         final KeyboardIconsSet iconsSet = KeyboardIconsSet.Companion.getInstance();
-        mIncognitoIcon = iconsSet.getNewDrawable(KeyboardIconsSet.NAME_INCOGNITO_KEY, context);
+        mIncognitoIcon = iconsSet.getNewDrawable(ToolbarKey.INCOGNITO.name(), context);
         mToolbarArrowIcon = iconsSet.getNewDrawable(KeyboardIconsSet.NAME_TOOLBAR_KEY, context);
         mBinIcon = iconsSet.getNewDrawable(KeyboardIconsSet.NAME_BIN, context);
 

--- a/app/src/main/java/helium314/keyboard/latin/utils/ToolbarUtils.kt
+++ b/app/src/main/java/helium314/keyboard/latin/utils/ToolbarUtils.kt
@@ -48,8 +48,6 @@ fun createToolbarKey(context: Context, iconsSet: KeyboardIconsSet, key: ToolbarK
     return button
 }
 
-// todo: performance ok, or cache in settings?
-//  better don't create a map when reading from settings on every press
 fun getCodeForToolbarKey(key: ToolbarKey) = Settings.getInstance().getCustomToolbarKeyCode(key) ?: when (key) {
     VOICE -> KeyCode.VOICE_INPUT
     CLIPBOARD -> KeyCode.CLIPBOARD
@@ -82,8 +80,6 @@ fun getCodeForToolbarKey(key: ToolbarKey) = Settings.getInstance().getCustomTool
     PAGE_END -> KeyCode.MOVE_END_OF_PAGE
 }
 
-// todo: performance ok, or cache in settings?
-//  better don't create a map when reading from settings on every press
 fun getCodeForToolbarKeyLongClick(key: ToolbarKey) = Settings.getInstance().getCustomToolbarLongpressCode(key) ?: when (key) {
     CLIPBOARD -> KeyCode.CLIPBOARD_PASTE
     UNDO -> KeyCode.REDO
@@ -197,7 +193,6 @@ private fun getEnabledToolbarKeys(prefs: SharedPreferences, pref: String, defaul
     }
 }
 
-// todo: add ~5 "custom toolbar key" 1-5
 fun toolbarKeysCustomizer(context: Context) {
     val padding = ResourceUtils.toPx(8, context.resources)
     val ll = LinearLayout(context).apply {
@@ -205,6 +200,7 @@ fun toolbarKeysCustomizer(context: Context) {
         setPadding(3 * padding, padding, padding, padding)
     }
     val d = AlertDialog.Builder(context)
+        .setTitle(R.string.customize_toolbar_key_codes)
         .setView(ScrollView(context).apply { addView(ll) })
         .setPositiveButton(R.string.dialog_close, null)
         .create()
@@ -221,7 +217,6 @@ fun toolbarKeysCustomizer(context: Context) {
         }
         b.reorderItemSwitch.isGone = true
         b.reorderItemDragIndicator.isGone = true
-
     }
     d.show()
 }

--- a/app/src/main/java/helium314/keyboard/latin/utils/ToolbarUtils.kt
+++ b/app/src/main/java/helium314/keyboard/latin/utils/ToolbarUtils.kt
@@ -199,37 +199,37 @@ fun toolbarKeysCustomizer(context: Context) {
         orientation = LinearLayout.VERTICAL
         setPadding(3 * padding, padding, padding, padding)
     }
-    val d = AlertDialog.Builder(context)
+    val dialog = AlertDialog.Builder(context)
         .setTitle(R.string.customize_toolbar_key_codes)
         .setView(ScrollView(context).apply { addView(ll) })
         .setPositiveButton(R.string.dialog_close, null)
         .create()
     val cf = BlendModeColorFilterCompat.createBlendModeColorFilterCompat(ContextCompat.getColor(context, R.color.foreground), BlendModeCompat.SRC_IN)
     ToolbarKey.entries.forEach { key ->
-        val b = ReorderDialogItemBinding.inflate(LayoutInflater.from(context), ll, true)
-        b.reorderItemIcon.setImageDrawable(KeyboardIconsSet.instance.getNewDrawable(key.name, context))
-        b.reorderItemIcon.colorFilter = cf
-        b.reorderItemIcon.isVisible = true
-        b.reorderItemName.text = key.name.lowercase().getStringResourceOrName("", context)
-        b.root.setOnClickListener {
+        val binding = ReorderDialogItemBinding.inflate(LayoutInflater.from(context), ll, true)
+        binding.reorderItemIcon.setImageDrawable(KeyboardIconsSet.instance.getNewDrawable(key.name, context))
+        binding.reorderItemIcon.colorFilter = cf
+        binding.reorderItemIcon.isVisible = true
+        binding.reorderItemName.text = key.name.lowercase().getStringResourceOrName("", context)
+        binding.root.setOnClickListener {
             toolbarKeyCustomizer(context, key)
-            d.dismiss()
+            dialog.dismiss()
         }
-        b.reorderItemSwitch.isGone = true
-        b.reorderItemDragIndicator.isGone = true
+        binding.reorderItemSwitch.isGone = true
+        binding.reorderItemDragIndicator.isGone = true
     }
-    d.show()
+    dialog.show()
 }
 
 @SuppressLint("SetTextI18n")
 private fun toolbarKeyCustomizer(context: Context, key: ToolbarKey) {
-    val v = LayoutInflater.from(context).inflate(R.layout.toolbar_key_customizer, null)
+    val layout = LayoutInflater.from(context).inflate(R.layout.toolbar_key_customizer, null)
     val prefs = DeviceProtectedUtils.getSharedPreferences(context)
     var keyCode: String? = null
     var longpressCode: String? = null
-    val b = AlertDialog.Builder(context)
+    val builder = AlertDialog.Builder(context)
         .setTitle(key.name.lowercase().getStringResourceOrName("", context))
-        .setView(ScrollView(context).apply { addView(v) })
+        .setView(ScrollView(context).apply { addView(layout) })
         .setPositiveButton(android.R.string.ok) { _, _ ->
             val newKeyCode = runCatching { keyCode?.toIntOrNull()?.checkAndConvertCode() }.getOrNull()?.takeIf { it < Char.MAX_VALUE.code }
             val newLongpressCode = runCatching { longpressCode?.toIntOrNull()?.checkAndConvertCode() }.getOrNull()?.takeIf { it < Char.MAX_VALUE.code }
@@ -241,7 +241,7 @@ private fun toolbarKeyCustomizer(context: Context, key: ToolbarKey) {
         }
         .setNegativeButton(android.R.string.cancel) { _, _ -> toolbarKeysCustomizer(context) }
     if (readCustomKeyCodes(prefs).containsKey(key.name) || readCustomLongpressCodes(prefs).containsKey(key.name))
-        b.setNeutralButton(R.string.button_default) { _, _ ->
+        builder.setNeutralButton(R.string.button_default) { _, _ ->
             val keys = readCustomKeyCodes(prefs).toMutableMap()
             keys.remove(key.name)
             prefs.edit().putString(Settings.PREF_TOOLBAR_CUSTOM_KEY_CODES, Json.encodeToString(keys)).apply()
@@ -250,23 +250,23 @@ private fun toolbarKeyCustomizer(context: Context, key: ToolbarKey) {
             prefs.edit().putString(Settings.PREF_TOOLBAR_CUSTOM_LONGPRESS_CODES, Json.encodeToString(longpressKeys)).apply()
             toolbarKeysCustomizer(context)
         }
-    val d = b.create()
+    val dialog = builder.create()
 
     fun checkOk() {
         val keyOk = keyCode == null
                 || runCatching { keyCode?.toIntOrNull()?.let { it.checkAndConvertCode() <= Char.MAX_VALUE.code } }.getOrNull() ?: false
         val longPressOk = longpressCode == null
                 || runCatching { longpressCode?.toIntOrNull()?.let { it.checkAndConvertCode() <= Char.MAX_VALUE.code } }.getOrNull() ?: false
-        d.getButton(DialogInterface.BUTTON_POSITIVE)?.isEnabled = keyOk && longPressOk
+        dialog.getButton(DialogInterface.BUTTON_POSITIVE)?.isEnabled = keyOk && longPressOk
     }
-    v.findViewById<EditText>(R.id.toolbar_key_code)?.apply {
+    layout.findViewById<EditText>(R.id.toolbar_key_code)?.apply {
         setText(getCodeForToolbarKey(key).toString())
         doAfterTextChanged {
             keyCode = it?.toString()
             checkOk()
         }
     }
-    v.findViewById<EditText>(R.id.toolbar_key_longpress_code)?.apply {
+    layout.findViewById<EditText>(R.id.toolbar_key_longpress_code)?.apply {
         setText(getCodeForToolbarKeyLongClick(key).toString())
         doAfterTextChanged {
             longpressCode = it?.toString()
@@ -274,7 +274,7 @@ private fun toolbarKeyCustomizer(context: Context, key: ToolbarKey) {
         }
     }
 
-    d.show()
+    dialog.show()
 }
 
 fun readCustomKeyCodes(prefs: SharedPreferences) = prefs.getString(Settings.PREF_TOOLBAR_CUSTOM_KEY_CODES, "")!!

--- a/app/src/main/res/layout/reorder_dialog_item.xml
+++ b/app/src/main/res/layout/reorder_dialog_item.xml
@@ -31,6 +31,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content" />
     <ImageView
+        android:id="@+id/reorder_item_drag_indicator"
         android:paddingEnd="10dp"
         android:src="@drawable/ic_drag_indicator"
         app:tint="@color/foreground_weak"

--- a/app/src/main/res/layout/toolbar_key_customizer.xml
+++ b/app/src/main/res/layout/toolbar_key_customizer.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:paddingHorizontal="10dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            style="@style/PreferenceTitleText"
+            android:text="@string/key_code" />
+        <EditText
+            android:id="@+id/toolbar_key_code"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1" />
+    </LinearLayout>
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            style="@style/PreferenceTitleText"
+            android:text="@string/long_press_code" />
+        <EditText
+            android:id="@+id/toolbar_key_longpress_code"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            style="@style/PreferenceTitleText"
+            android:layout_weight="1" />
+    </LinearLayout>
+    <GridLayout
+        android:id="@+id/toolbar_icon_grid"
+        android:columnCount="7"
+        android:layout_gravity="center_horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/toolbar_key_customizer.xml
+++ b/app/src/main/res/layout/toolbar_key_customizer.xml
@@ -38,11 +38,5 @@
             android:inputType="number"
             android:layout_weight="1" />
     </LinearLayout>
-    <GridLayout
-        android:id="@+id/toolbar_icon_grid"
-        android:columnCount="7"
-        android:layout_gravity="center_horizontal"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/toolbar_key_customizer.xml
+++ b/app/src/main/res/layout/toolbar_key_customizer.xml
@@ -18,6 +18,7 @@
             android:id="@+id/toolbar_key_code"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:inputType="number"
             android:layout_weight="1" />
     </LinearLayout>
     <LinearLayout
@@ -34,7 +35,7 @@
             android:id="@+id/toolbar_key_longpress_code"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            style="@style/PreferenceTitleText"
+            android:inputType="number"
             android:layout_weight="1" />
     </LinearLayout>
     <GridLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -895,8 +895,8 @@ New dictionary:
     <string name="var_toolbar_direction">Variable toolbar direction</string>
     <!-- Description of the variable toolbar direction setting -->
     <string name="var_toolbar_direction_summary">Reverse direction when a right-to-left keyboard subtype is selected</string>
-    <!-- Title of the setting to customize toolbar keys -->
-    <string name="customize_toolbar_keys">Customize toolbar keys</string>
+    <!-- Title of the setting to customize toolbar key codes -->
+    <string name="customize_toolbar_key_codes">Customize toolbar key codes</string>
     <!-- Text for showing / setting key code -->
     <string name="key_code">Key code</string>
     <!-- Text for showing / setting long press code -->
@@ -911,4 +911,6 @@ New dictionary:
     <string name="auto_hide_toolbar_summary">Hide the toolbar when suggestions become available</string>
     <!-- Toast message shown when content is copied to the clipboard -->
     <string name="toast_msg_clipboard_copy">Content copied</string>
+    <!-- Title of the setting to customize icons for keyboard and toolbar keys -->
+    <string name="customize_icons">Customize icons</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -881,6 +881,12 @@ New dictionary:
     <string name="label_pause_key" tools:keep="@string/label_pause_key">Pause</string>
     <!-- Label for "Wait" key of phone number keyboard.  Must be short to fit on key. 5 chars or less is preferable.  [CHAR LIMIT=7]-->
     <string name="label_wait_key" tools:keep="@string/label_wait_key">Wait</string>
+    <!-- Label for enter key, currently used only for showing the icon name -->
+    <string name="label_enter_key" tools:keep="@string/label_enter_key">Enter</string>
+    <!-- Label for tabulator key, currently used only for showing the icon name -->
+    <string name="label_tab_key" tools:keep="@string/label_tab_key">Tab</string>
+    <!-- Label for delete key, currently used only for showing the icon name -->
+    <string name="label_delete_key" tools:keep="@string/label_delete_key">Delete</string>
     <!-- Title of the setting for horizontal spacebar swipe gesture -->
     <string name="show_horizontal_space_swipe">Horizontal spacebar swipe gesture</string>
     <!-- Title of the setting for vertical spacebar swipe gesture -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -895,6 +895,12 @@ New dictionary:
     <string name="var_toolbar_direction">Variable toolbar direction</string>
     <!-- Description of the variable toolbar direction setting -->
     <string name="var_toolbar_direction_summary">Reverse direction when a right-to-left keyboard subtype is selected</string>
+    <!-- Title of the setting to customize toolbar keys -->
+    <string name="customize_toolbar_keys">Customize toolbar keys</string>
+    <!-- Text for showing / setting key code -->
+    <string name="key_code">Key code</string>
+    <!-- Text for showing / setting long press code -->
+    <string name="long_press_code">Long press code</string>
     <!-- Title of the setting for showing the toolbar automatically -->
     <string name="auto_show_toolbar">Auto show toolbar</string>
     <!-- Description of the setting for showing the toolbar automatically -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -894,9 +894,17 @@ New dictionary:
     <!-- Label for shift key when locked (caps lock mode), currently used only for showing the icon name -->
     <string name="label_shift_key_locked" tools:keep="@string/label_shift_key_locked">Caps lock</string>
     <!-- Label for the short space key (in number layouts), currently used only for showing the icon name -->
-    <string name="label_space_key_for_number_layout" tools:keep="@string/label_space_key_for_number_layout">Space (short)</string>
-    <!-- Label for stop onehanded mode, currently used only for showing the icon name -->
+    <string name="label_space_key_for_number_layout" tools:keep="@string/label_space_key_for_number_layout">Space (number layout)</string>
+    <!-- Label for key to stop onehanded mode, currently used only for showing the icon name -->
     <string name="label_stop_onehanded_mode_key" tools:keep="@string/label_stop_onehanded_mode_key">End one-handed mode</string>
+    <!-- Label for key to resize onehanded mode, currently used only for showing the icon name -->
+    <string name="label_resize_onehanded_key" tools:keep="@string/label_resize_onehanded_key">Resize one-handed mode</string>
+    <!-- Label for key to switch side of onehanded mode, currently used only for showing the icon name -->
+    <string name="label_switch_onehanded_key" tools:keep="@string/label_switch_onehanded_key">Switch one-handed mode side</string>
+    <!-- Label for voice key when disabled, currently used only for showing the icon name -->
+    <string name="label_shortcut_key_disabled" tools:keep="@string/label_shortcut_key_disabled">Voice input disabled</string>
+    <!-- Label for toolbar key, currently used only for showing the icon name -->
+    <string name="label_toolbar_key" tools:keep="@string/label_toolbar_key">Show / hide toolbar</string>
     <!-- Label for language switch key, currently used only for showing the icon name -->
     <string name="label_language_switch_key" tools:keep="@string/label_language_switch_key">@string/show_language_switch_key</string>
     <!-- Label for zero-width joiner key, currently used only for showing the icon name -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -887,6 +887,22 @@ New dictionary:
     <string name="label_tab_key" tools:keep="@string/label_tab_key">Tab</string>
     <!-- Label for delete key, currently used only for showing the icon name -->
     <string name="label_delete_key" tools:keep="@string/label_delete_key">Delete</string>
+    <!-- Label for shift key, currently used only for showing the icon name -->
+    <string name="label_shift_key" tools:keep="@string/label_shift_key">Shift</string>
+    <!-- Label for shift key when active, currently used only for showing the icon name -->
+    <string name="label_shift_key_shifted" tools:keep="@string/label_shift_key_shifted">Shift (shifted)</string>
+    <!-- Label for shift key when locked (caps lock mode), currently used only for showing the icon name -->
+    <string name="label_shift_key_locked" tools:keep="@string/label_shift_key_locked">Caps lock</string>
+    <!-- Label for the short space key (in number layouts), currently used only for showing the icon name -->
+    <string name="label_space_key_for_number_layout" tools:keep="@string/label_space_key_for_number_layout">Space (short)</string>
+    <!-- Label for stop onehanded mode, currently used only for showing the icon name -->
+    <string name="label_stop_onehanded_mode_key" tools:keep="@string/label_stop_onehanded_mode_key">End one-handed mode</string>
+    <!-- Label for language switch key, currently used only for showing the icon name -->
+    <string name="label_language_switch_key" tools:keep="@string/label_language_switch_key">@string/show_language_switch_key</string>
+    <!-- Label for zero-width joiner key, currently used only for showing the icon name -->
+    <string name="label_zwj_key" tools:keep="@string/label_zwj_key">Zero-width joiner</string>
+    <!-- Label for zero-width non-joiner key, currently used only for showing the icon name -->
+    <string name="label_zwnj_key" tools:keep="@string/label_zwnj_key">Zero-width non-joiner</string>
     <!-- Title of the setting for horizontal spacebar swipe gesture -->
     <string name="show_horizontal_space_swipe">Horizontal spacebar swipe gesture</string>
     <!-- Title of the setting for vertical spacebar swipe gesture -->

--- a/app/src/main/res/xml/prefs_screen_appearance.xml
+++ b/app/src/main/res/xml/prefs_screen_appearance.xml
@@ -27,7 +27,7 @@
 
         <Preference
             android:key="custom_icon_names"
-            android:title="customize icons" />
+            android:title="@string/customize_icons" />
 
         <ListPreference
             android:key="theme_colors"

--- a/app/src/main/res/xml/prefs_screen_appearance.xml
+++ b/app/src/main/res/xml/prefs_screen_appearance.xml
@@ -25,6 +25,10 @@
             android:defaultValue="Material"
             latin:singleLineTitle="false" />
 
+        <Preference
+            android:key="custom_icon_names"
+            android:title="customize icons" />
+
         <ListPreference
             android:key="theme_colors"
             android:title="@string/theme_colors"

--- a/app/src/main/res/xml/prefs_screen_toolbar.xml
+++ b/app/src/main/res/xml/prefs_screen_toolbar.xml
@@ -21,6 +21,10 @@
         android:key="clipboard_toolbar_keys"
         android:title="@string/clipboard_toolbar_keys" />
 
+    <Preference
+        android:key="customize_keys"
+        android:title="@string/customize_toolbar_keys" />
+
     <SwitchPreference
         android:key="quick_pin_toolbar_keys"
         android:title="@string/quick_pin_toolbar_keys"
@@ -48,9 +52,5 @@
         android:summary="@string/var_toolbar_direction_summary"
         android:defaultValue="true"
         android:persistent="true" />
-
-    <Preference
-        android:key="customize_keys"
-        android:title="@string/customize_toolbar_keys" />
 
 </PreferenceScreen>

--- a/app/src/main/res/xml/prefs_screen_toolbar.xml
+++ b/app/src/main/res/xml/prefs_screen_toolbar.xml
@@ -22,8 +22,8 @@
         android:title="@string/clipboard_toolbar_keys" />
 
     <Preference
-        android:key="customize_keys"
-        android:title="@string/customize_toolbar_keys" />
+        android:key="customize_key_codes"
+        android:title="@string/customize_toolbar_key_codes" />
 
     <SwitchPreference
         android:key="quick_pin_toolbar_keys"

--- a/app/src/main/res/xml/prefs_screen_toolbar.xml
+++ b/app/src/main/res/xml/prefs_screen_toolbar.xml
@@ -49,4 +49,8 @@
         android:defaultValue="true"
         android:persistent="true" />
 
+    <Preference
+        android:key="customize_keys"
+        android:title="@string/customize_toolbar_keys" />
+
 </PreferenceScreen>


### PR DESCRIPTION
Customizing icons was already planned, will be implemented here.
Since people want ever more toolbar keys, and adding everything myself is annoying and makes the toolbar selection menu horribly long, I decided to add the code customization in the same menu.

What's missing
* ~actually saving the settings~
* ~sanity check for the codes (using `checkAndConvertCode`)~
* ~restriction of the `EditText` fields (either to numbers, or allow labels with `processCode`)~
* ~disable ok button of key code not ok~
* ~nicer key selection dialog~
* ~readout of customized toolbar key codes~
* ~testing~
* ~strings for everything~
* some dummy toolbar keys that are just for doing custom stuff (when people don't want to modify other keys)
* maybe find a way to show the size difference between holo and other icons when customizing icons