### PR TITLE
Greek accent/dead key support

### DIFF
--- a/app/src/main/assets/layouts/greek.json
+++ b/app/src/main/assets/layouts/greek.json
@@ -23,7 +23,11 @@
     { "label": "η" },
     { "label": "ξ" },
     { "label": "κ" },
-    { "label": "λ" }
+    { "label": "λ" },
+    { "$": "shift_state_selector",
+      "shiftedManual": { "code": 776, "label": "¨", "isDeadKey": true },
+      "default": { "code": 769, "label": "´", "isDeadKey": true }
+    }
   ],
   [
     { "label": "ζ" },

--- a/app/src/main/assets/layouts/greek.json
+++ b/app/src/main/assets/layouts/greek.json
@@ -25,8 +25,8 @@
     { "label": "κ" },
     { "label": "λ" },
     { "$": "shift_state_selector",
-      "shiftedManual": { "code": 776, "label": "¨", "isDeadKey": true },
-      "default": { "code": 769, "label": "´", "isDeadKey": true }
+      "shiftedManual": { "code": 776, "label": "¨" },
+      "default": { "code": 769, "label": "´" }
     }
   ],
   [

--- a/app/src/main/java/helium314/keyboard/event/Event.kt
+++ b/app/src/main/java/helium314/keyboard/event/Event.kt
@@ -146,6 +146,7 @@ class Event private constructor(
         }
 
         // This creates an input event for a dead character. @see {@link #FLAG_DEAD}
+        @JvmStatic
         fun createDeadEvent(codePoint: Int, keyCode: Int, metaState: Int, next: Event?): Event { // TODO: add an argument or something if we ever create a software layout with dead keys.
             return Event(EVENT_TYPE_INPUT_KEYPRESS, null, codePoint, keyCode, metaState,
                     Constants.EXTERNAL_KEYBOARD_COORDINATE, Constants.EXTERNAL_KEYBOARD_COORDINATE,

--- a/app/src/main/java/helium314/keyboard/event/Event.kt
+++ b/app/src/main/java/helium314/keyboard/event/Event.kt
@@ -146,11 +146,17 @@ class Event private constructor(
         }
 
         // This creates an input event for a dead character. @see {@link #FLAG_DEAD}
-        @JvmStatic
-        fun createDeadEvent(codePoint: Int, keyCode: Int, metaState: Int, next: Event?): Event { // TODO: add an argument or something if we ever create a software layout with dead keys.
+        fun createDeadEvent(codePoint: Int, keyCode: Int, metaState: Int, next: Event?): Event {
             return Event(EVENT_TYPE_INPUT_KEYPRESS, null, codePoint, keyCode, metaState,
                     Constants.EXTERNAL_KEYBOARD_COORDINATE, Constants.EXTERNAL_KEYBOARD_COORDINATE,
                     null, FLAG_DEAD, next)
+        }
+
+        // This creates an input event for a dead character. @see {@link #FLAG_DEAD}
+        @JvmStatic
+        fun createSoftwareDeadEvent(codePoint: Int, keyCode: Int, metaState: Int, x: Int, y: Int, next: Event?): Event {
+            return Event(EVENT_TYPE_INPUT_KEYPRESS, null, codePoint, keyCode, metaState, x, y,
+                null, FLAG_DEAD, next)
         }
 
         /**

--- a/app/src/main/java/helium314/keyboard/latin/LatinIME.java
+++ b/app/src/main/java/helium314/keyboard/latin/LatinIME.java
@@ -1494,7 +1494,15 @@ public class LatinIME extends InputMethodService implements
         // this transformation, it should be done already before calling onEvent.
         final int keyX = mainKeyboardView.getKeyX(x);
         final int keyY = mainKeyboardView.getKeyY(y);
-        final Event event = createSoftwareKeypressEvent(codePoint, metaState, keyX, keyY, isKeyRepeat);
+        final Event event;
+
+        // checking if the character is a combining accent
+        if (0x300 <= codePoint && codePoint <= 0x35b) {
+            event = Event.createDeadEvent(codePoint, 0, metaState, null);
+        } else {
+            event = createSoftwareKeypressEvent(codePoint, metaState, keyX, keyY, isKeyRepeat);
+        }
+
         onEvent(event);
     }
 

--- a/app/src/main/java/helium314/keyboard/latin/LatinIME.java
+++ b/app/src/main/java/helium314/keyboard/latin/LatinIME.java
@@ -1498,7 +1498,7 @@ public class LatinIME extends InputMethodService implements
 
         // checking if the character is a combining accent
         if (0x300 <= codePoint && codePoint <= 0x35b) {
-            event = Event.createDeadEvent(codePoint, 0, metaState, null);
+            event = Event.createSoftwareDeadEvent(codePoint, 0, metaState, x, y, null);
         } else {
             event = createSoftwareKeypressEvent(codePoint, metaState, keyX, keyY, isKeyRepeat);
         }


### PR DESCRIPTION
Fixes #760 , if a key has its codepoint as a combining accent (U+0300 <= codepoint <= U+035B), it is automatically treated as a dead key.