### PR TITLE
Add schwa ə in Italian keyboard layout for inclusive language

### DIFF
--- a/app/src/main/assets/locale_key_texts/it.txt
+++ b/app/src/main/assets/locale_key_texts/it.txt
@@ -1,6 +1,6 @@
 [popup_keys]
 a à ª
-e è é
+e è é ə
 i ì
 o ò ó º
 u ù


### PR DESCRIPTION
This pull request adds the schwa letter (`ə`) to the Italian keyboard layout, in the popup for the `e` key. The `e` key has been chosen to mimic the implementation of the Apple default iOS keyboard.

I am not sure whether the uppercase schwa (`Ə`) would be added automatically or whether an action is needed. Sadly, I cannot test the code

This would resolve #1274. The issue contains more information on inclusive language in Italian.