### PR TITLE
fix link to license file in about screen

### DIFF
--- a/app/src/main/res/xml/prefs_screen_about.xml
+++ b/app/src/main/res/xml/prefs_screen_about.xml
@@ -24,7 +24,7 @@
         android:summary="@string/gnu_gpl"
         android:icon="@drawable/ic_settings_about_license">
         <intent android:action="android.intent.action.VIEW"
-            android:data="https://github.com/Helium314/HeliBoard/blob/main/LICENSE-GPL-3" />
+            android:data="https://github.com/Helium314/HeliBoard/blob/main/LICENSE" />
     </Preference>
 
     <Preference


### PR DESCRIPTION
missed in 1e7ea7d69946b04e66e3ed99cd852a40c081656f