### PR TITLE
Improve behavior for language swipe cycling

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListener.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListener.java
@@ -97,6 +97,7 @@ public interface KeyboardActionListener {
      */
     boolean onHorizontalSpaceSwipe(int steps);
     boolean onVerticalSpaceSwipe(int steps);
+    void resetSubtypeSwitchCount();
     boolean toggleNumpad(boolean withSliding, boolean forceReturnToAlpha);
 
     void onMoveDeletePointer(int steps);
@@ -147,6 +148,8 @@ public interface KeyboardActionListener {
         public boolean toggleNumpad(boolean withSliding, boolean forceReturnToAlpha) {
             return false;
         }
+        @Override
+        public void resetSubtypeSwitchCount() {}
         @Override
         public void onMoveDeletePointer(int steps) {}
         @Override

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListener.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListener.java
@@ -97,7 +97,7 @@ public interface KeyboardActionListener {
      */
     boolean onHorizontalSpaceSwipe(int steps);
     boolean onVerticalSpaceSwipe(int steps);
-    void resetSubtypeSwitchCount();
+    void onEndSpaceSwipe();
     boolean toggleNumpad(boolean withSliding, boolean forceReturnToAlpha);
 
     void onMoveDeletePointer(int steps);
@@ -149,7 +149,7 @@ public interface KeyboardActionListener {
             return false;
         }
         @Override
-        public void resetSubtypeSwitchCount() {}
+        public void onEndSpaceSwipe() {}
         @Override
         public void onMoveDeletePointer(int steps) {}
         @Override

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
@@ -85,7 +85,7 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
         else -> false
     }
 
-    override fun resetSubtypeSwitchCount(){
+    override fun onEndSpaceSwipe(){
         mSubtypeSwitchCount = 0
     }
 

--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -1076,7 +1076,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
             if (mInHorizontalSwipe || mInVerticalSwipe) {
                 mInHorizontalSwipe = false;
                 mInVerticalSwipe = false;
-                sListener.resetSubtypeSwitchCount();
+                sListener.onEndSpaceSwipe();
                 return;
             }
         }

--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -1076,6 +1076,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
             if (mInHorizontalSwipe || mInVerticalSwipe) {
                 mInHorizontalSwipe = false;
                 mInVerticalSwipe = false;
+                sListener.resetSubtypeSwitchCount();
                 return;
             }
         }

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -152,7 +152,6 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
 
     public static final String PREF_SPACE_TO_CHANGE_LANG = "prefs_long_press_keyboard_to_change_lang";
     public static final String PREF_LANGUAGE_SWIPE_DISTANCE = "language_swipe_distance";
-    public static final int DEFAULT_LANGUAGE_SWIPE_DISTANCE = 10;
 
     public static final String PREF_ENABLE_CLIPBOARD_HISTORY = "enable_clipboard_history";
     public static final String PREF_CLIPBOARD_HISTORY_RETENTION_TIME = "clipboard_history_retention_time";
@@ -458,7 +457,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     }
 
     public static int readDefaultLanguageSwipeDistance(final Resources res) {
-        return DEFAULT_LANGUAGE_SWIPE_DISTANCE;
+        return 10;
     }
 
     public static boolean readDeleteSwipeEnabled(final SharedPreferences prefs) {

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -151,6 +151,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_MORE_POPUP_KEYS = "more_popup_keys";
 
     public static final String PREF_SPACE_TO_CHANGE_LANG = "prefs_long_press_keyboard_to_change_lang";
+    public static final String PREF_LANGUAGE_SWIPE_DISTANCE = "language_swipe_distance";
 
     public static final String PREF_ENABLE_CLIPBOARD_HISTORY = "enable_clipboard_history";
     public static final String PREF_CLIPBOARD_HISTORY_RETENTION_TIME = "clipboard_history_retention_time";
@@ -445,6 +446,18 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
             case "toggle_numpad" -> KeyboardActionListener.SWIPE_TOGGLE_NUMPAD;
             default -> KeyboardActionListener.SWIPE_NO_ACTION;
         };
+    }
+
+    public static int readLanguageSwipeDistance(final SharedPreferences prefs,
+                                                final Resources res) {
+        final int sensitivity = prefs.getInt(
+                PREF_LANGUAGE_SWIPE_DISTANCE, UNDEFINED_PREFERENCE_VALUE_INT);
+        return (sensitivity != UNDEFINED_PREFERENCE_VALUE_INT) ? sensitivity
+                : readDefaultLanguageSwipeDistance(res);
+    }
+
+    public static int readDefaultLanguageSwipeDistance(final Resources res) {
+        return res.getInteger(R.integer.config_default_language_swipe_distance);
     }
 
     public static boolean readDeleteSwipeEnabled(final SharedPreferences prefs) {

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -457,7 +457,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     }
 
     public static int readDefaultLanguageSwipeDistance(final Resources res) {
-        return 10;
+        return 5;
     }
 
     public static boolean readDeleteSwipeEnabled(final SharedPreferences prefs) {

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -152,6 +152,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
 
     public static final String PREF_SPACE_TO_CHANGE_LANG = "prefs_long_press_keyboard_to_change_lang";
     public static final String PREF_LANGUAGE_SWIPE_DISTANCE = "language_swipe_distance";
+    public static final int DEFAULT_LANGUAGE_SWIPE_DISTANCE = 10;
 
     public static final String PREF_ENABLE_CLIPBOARD_HISTORY = "enable_clipboard_history";
     public static final String PREF_CLIPBOARD_HISTORY_RETENTION_TIME = "clipboard_history_retention_time";
@@ -457,7 +458,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     }
 
     public static int readDefaultLanguageSwipeDistance(final Resources res) {
-        return res.getInteger(R.integer.config_default_language_swipe_distance);
+        return DEFAULT_LANGUAGE_SWIPE_DISTANCE;
     }
 
     public static boolean readDeleteSwipeEnabled(final SharedPreferences prefs) {

--- a/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
@@ -80,6 +80,7 @@ public class SettingsValues {
     public final boolean mBlockPotentiallyOffensive;
     public final int mSpaceSwipeHorizontal;
     public final int mSpaceSwipeVertical;
+    public final int mLanguageSwipeDistance;
     public final boolean mDeleteSwipeEnabled;
     public final boolean mAutospaceAfterPunctuationEnabled;
     public final boolean mClipboardHistoryEnabled;
@@ -227,6 +228,7 @@ public class SettingsValues {
         mDisplayOrientation = res.getConfiguration().orientation;
         mSpaceSwipeHorizontal = Settings.readHorizontalSpaceSwipe(prefs);
         mSpaceSwipeVertical = Settings.readVerticalSpaceSwipe(prefs);
+        mLanguageSwipeDistance = Settings.readLanguageSwipeDistance(prefs, res);
         mDeleteSwipeEnabled = Settings.readDeleteSwipeEnabled(prefs);
         mAutospaceAfterPunctuationEnabled = Settings.readAutospaceAfterPunctuationEnabled(prefs);
         mClipboardHistoryEnabled = Settings.readClipboardHistoryEnabled(prefs);

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -377,6 +377,7 @@
     <string name="prefs_long_press_symbol_for_numpad">নম্বর প্যাডের জন্য প্রতীক বোতামে দীর্ঘ চাপ</string>
     <string name="var_toolbar_direction">টুলবারের পরিবর্তনশীল দিক</string>
     <string name="var_toolbar_direction_summary">ডান থেকে বাম কিবোর্ড নির্বাচন করলে দিক বিপরীত হবে</string>
+    <string name="prefs_language_swipe_distance">ভাষা পরিবর্তন অভিস্পর্শের দূরত্ব</string>
     <string name="subtype_generic_student"><xliff:g id="LANGUAGE_NAME" example="Russian">%s</xliff:g> (শিক্ষার্থী)</string>
     <string name="language_switch_key_behavior">ভাষা পরিবর্তন বোতামের আচরণ</string>
     <string name="pinned_toolbar_keys">পিন করে রাখা টুলবার বোতাম নির্বাচন</string>

--- a/app/src/main/res/values/config-common.xml
+++ b/app/src/main/res/values/config-common.xml
@@ -30,11 +30,6 @@
     <bool name="config_default_vibration_enabled">false</bool>
     <integer name="config_max_vibration_duration">100</integer>
 
-    <integer name="config_default_language_swipe_distance">10</integer>
-    <integer name="config_min_language_swipe_distance">2</integer>
-    <integer name="config_max_language_swipe_distance">18</integer>
-    <integer name="config_language_swipe_distance_step">1</integer>
-
     <integer name="config_default_longpress_key_timeout">300</integer>
     <integer name="config_max_longpress_timeout">700</integer>
     <integer name="config_min_longpress_timeout">100</integer>

--- a/app/src/main/res/values/config-common.xml
+++ b/app/src/main/res/values/config-common.xml
@@ -30,6 +30,11 @@
     <bool name="config_default_vibration_enabled">false</bool>
     <integer name="config_max_vibration_duration">100</integer>
 
+    <integer name="config_default_language_swipe_distance">10</integer>
+    <integer name="config_min_language_swipe_distance">2</integer>
+    <integer name="config_max_language_swipe_distance">18</integer>
+    <integer name="config_language_swipe_distance_step">1</integer>
+
     <integer name="config_default_longpress_key_timeout">300</integer>
     <integer name="config_max_longpress_timeout">700</integer>
     <integer name="config_min_longpress_timeout">100</integer>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -946,6 +946,8 @@ New dictionary:
     <string name="var_toolbar_direction">Variable toolbar direction</string>
     <!-- Description of the variable toolbar direction setting -->
     <string name="var_toolbar_direction_summary">Reverse direction when a right-to-left keyboard subtype is selected</string>
+    <!-- Title of the settings for adjusting the language swipe gesture distance -->
+    <string name="prefs_language_swipe_distance">Switch language swipe distance</string>
     <!-- Title of the setting to customize toolbar key codes -->
     <string name="customize_toolbar_key_codes">Customize toolbar key codes</string>
     <!-- Confirmation message when resetting all custom toolbar key codes -->

--- a/app/src/main/res/xml/prefs_screen_advanced.xml
+++ b/app/src/main/res/xml/prefs_screen_advanced.xml
@@ -43,6 +43,13 @@
         android:title="@string/show_vertical_space_swipe"
         latin:singleLineTitle="false" />
 
+    <helium314.keyboard.latin.settings.SeekBarDialogPreference
+        android:key="language_swipe_distance"
+        android:title="@string/prefs_language_swipe_distance"
+        latin:minValue="@integer/config_min_language_swipe_distance"
+        latin:maxValue="@integer/config_max_language_swipe_distance"
+        latin:stepValue="@integer/config_language_swipe_distance_step" />
+
     <SwitchPreference
         android:key="delete_swipe"
         android:title="@string/delete_swipe"

--- a/app/src/main/res/xml/prefs_screen_advanced.xml
+++ b/app/src/main/res/xml/prefs_screen_advanced.xml
@@ -46,9 +46,9 @@
     <helium314.keyboard.latin.settings.SeekBarDialogPreference
         android:key="language_swipe_distance"
         android:title="@string/prefs_language_swipe_distance"
-        latin:minValue="@integer/config_min_language_swipe_distance"
-        latin:maxValue="@integer/config_max_language_swipe_distance"
-        latin:stepValue="@integer/config_language_swipe_distance_step" />
+        latin:minValue="2"
+        latin:maxValue="18"
+        latin:stepValue="1" />
 
     <SwitchPreference
         android:key="delete_swipe"


### PR DESCRIPTION
Implement logic to stop cycling through Switch languages swipe when all subtypes are cycled.

Infinite cycling is prevented through languages by checking if the number of attempted switches exceeds the number of available subtypes. This ensures that the user cannot endlessly cycle through languages beyond the available options.

fixes #614, #255

code from #656 by @codokie 

Tested on:
Samsung M32, Android 13
