### PR TITLE
Added Bengali (India) / Baishakhi layout

### DIFF
--- a/app/src/main/assets/layouts/main/bengali_baishakhi.json
+++ b/app/src/main/assets/layouts/main/bengali_baishakhi.json
@@ -1,0 +1,127 @@
+[
+    [
+      { "$": "shift_state_selector",
+        "manualOrLocked": { "label": "ঢ", "labelFlags": 1073741824 },
+        "default": { "label": "ড", "popup": { "relevant": [{ "label": "ঢ" }]}}
+      },
+      { "$": "shift_state_selector",
+        "manualOrLocked": { "label": "ূ", "labelFlags": 1073741824 },
+        "default": { "label": "ী", "popup": { "relevant": [{ "label": "ূ" }]}}
+      },
+      { "$": "shift_state_selector",
+        "manualOrLocked": { "label": "এ", "labelFlags": 1073741824 },
+        "default": { "label": "ে", "popup": { "relevant": [{ "label": "ঐ" }]}}
+      },
+      { "$": "shift_state_selector",
+        "manualOrLocked": { "label": "ৃ", "labelFlags": 1073741824 },
+        "default": { "label": "র", "popup": { "main": { "label": "ঋ" }, "relevant": [{ "label": "র‍্য" }]}}
+      },
+      { "$": "shift_state_selector",
+        "manualOrLocked": { "label": "ঠ", "labelFlags": 1073741824 },
+        "default": { "label": "ট", "popup": { "relevant": [{ "label": "ঠ" }]}}
+      },
+      { "$": "shift_state_selector",
+        "manualOrLocked": { "label": "য়", "labelFlags": 1073741824 },
+        "default": { "label": "য", "popup": { "relevant": [{ "label": "য়" }]}}
+      },
+      { "$": "shift_state_selector",
+        "manualOrLocked": { "label": "উ", "labelFlags": 1073741824 },
+        "default": { "label": "ু", "popup": { "relevant": [{ "label": "ঊ" }]}}
+      },
+      { "$": "shift_state_selector",
+        "manualOrLocked": { "label": "ই", "labelFlags": 1073741824 },
+        "default": { "label": "ি", "popup": { "relevant": [{ "label": "ঈ" }]}}
+      },
+      { "$": "shift_state_selector",
+        "manualOrLocked": { "label": "ও", "labelFlags": 1073741824 },
+        "default": { "label": "ো", "popup": { "relevant": [{ "label": "ঔ" }]}}
+      },
+      { "$": "shift_state_selector",
+        "manualOrLocked": { "label": "ফ", "labelFlags": 1073741824 },
+        "default": { "label": "প", "popup": { "relevant": [{ "label": "ফ" }]}}
+      }
+    ],
+    [
+      { "$": "shift_state_selector",
+        "manualOrLocked": { "label": "অ", "labelFlags": 1073741824 },
+        "default": { "label": "া", "popup": { "relevant": [{ "label": "আ" }]}}
+      },
+      { "$": "shift_state_selector",
+        "manualOrLocked": { "label": "শ", "labelFlags": 1073741824 },
+        "default": { "label": "স", "popup": { "relevant": [{ "label": "ষ" }]}}
+      },
+      { "$": "shift_state_selector",
+        "manualOrLocked": { "label": "ধ", "labelFlags": 1073741824 },
+        "default": { "label": "দ", "popup": { "relevant": [{ "label": "ধ" }]}}
+      },
+      { "$": "shift_state_selector",
+        "manualOrLocked": { "label": "থ", "labelFlags": 1073741824 },
+        "default": { "label": "ত",  "popup": { "main": { "label": "থ" }, "relevant": [{ "label": "ৎ" }]}}
+      },
+      { "$": "shift_state_selector",
+        "manualOrLocked": { "label": "ঘ", "labelFlags": 1073741824 },
+        "default": { "label": "গ", "popup": { "relevant": [{ "label": "ঘ" }]}}
+      },
+      { "$": "shift_state_selector",
+        "manualOrLocked": { "label": "হ", "labelFlags": 1073741824 },
+        "default": { "label": "্", "popup": { "relevant": [{ "label": "ঃ" }]}}
+      },
+      { "$": "shift_state_selector",
+        "manualOrLocked": { "label": "ঝ", "labelFlags": 1073741824 },
+        "default": { "label": "জ", "popup": { "relevant": [{ "label": "ঝ" }]}}
+      },
+      { "$": "shift_state_selector",
+        "manualOrLocked": { "label": "খ", "labelFlags": 1073741824 },
+        "default": { "label": "ক" }
+      },
+      { "$": "shift_state_selector",
+        "manualOrLocked": { "label": "ং", "labelFlags": 1073741824 },
+        "default": { "label": "ল", "popup": { "relevant": [{ "label": "ং" }]}}
+      }
+    ],
+    [
+      { "$": "shift_state_selector",
+        "manualOrLocked": { "label": "ৌ", "labelFlags": 1073741824 },
+        "default": { "label": "ৈ", "popup": { "relevant": [{ "label": "ৌ" }]}}
+      },
+      { "$": "shift_state_selector",
+        "manualOrLocked": { "label": "ঢ়", "labelFlags": 1073741824 },
+        "default": { "label": "ড়", "popup": { "relevant": [{ "label": "ঢ়" }]}}
+      },
+      { "$": "shift_state_selector",
+        "manualOrLocked": { "label": "ছ", "labelFlags": 1073741824 },
+        "default": { "label": "চ", "popup": { "relevant": [{ "label": "ছ" }]}}
+      },
+      { "$": "shift_state_selector",
+        "manualOrLocked": { "label": "ঁ", "labelFlags": 1073741824, "popup": { "relevant": [
+            { "label": "!autoColumnOrder!6" },
+            { "label": "়" },
+            { "label": "ৄ" },
+            { "label": "ঽ" },
+            { "label": "ৢ" },
+            { "label": "ৱ" },
+            { "label": "ৣ" },
+            { "label": "ৗ" },
+            { "label": "ৠ" },
+            { "label": "৺" },
+            { "label": "ঌ" },
+            { "label": "ৰ" },
+            { "label": "ৡ"}
+        ]}},
+        "default": { "label": "ঞ", "popup": { "relevant": [{ "label": "ঁ" }]}}
+      },
+      { "$": "shift_state_selector",
+        "manualOrLocked": { "label": "ভ", "labelFlags": 1073741824 },
+        "default": { "label": "ব", "popup": { "relevant": [{ "label": "ভ" }]}}
+      },
+      { "$": "shift_state_selector",
+        "manualOrLocked": { "label": "ণ", "labelFlags": 1073741824 },
+        "default": { "label": "ন", "popup": { "relevant": [{ "label": "ণ" }]}}
+      },
+      { "$": "shift_state_selector",
+        "manualOrLocked": { "label": "ঙ", "labelFlags": 1073741824 },
+        "default": { "label": "ম", "popup": { "relevant": [{ "label": "ঁ" }]}}
+      }
+    ]
+  ]
+  

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -146,6 +146,7 @@
     <string name="subtype_generic_traditional"><xliff:g id="LANGUAGE_NAME" example="Nepali">%s</xliff:g> (প্রথাগত)</string>
     <string name="subtype_with_layout_bn_BD"><xliff:g id="LANGUAGE_NAME" example="Bangla">%s</xliff:g> (অক্ষর)</string>
     <string name="subtype_probhat_bn_BD"><xliff:g id="LANGUAGE_NAME" example="Bangla">%s</xliff:g> (প্রভাত)</string>
+    <string name="subtype_baishakhi_bn_IN"><xliff:g id="LANGUAGE_NAME" example="Bengali">%s</xliff:g> (বৈশাখী)</string>
     <string name="subtype_generic_compact"><xliff:g id="LANGUAGE_NAME" example="Hindi">%s</xliff:g> (সংক্ষিপ্ত)</string>
     <string name="subtype_generic_sebeolsik_390"><xliff:g id="LANGUAGE_NAME" example="Korean">%s</xliff:g> (সেবালসিক 390)</string>
     <string name="subtype_generic_sebeolsik_final"><xliff:g id="LANGUAGE_NAME" example="Korean">%s</xliff:g> (সেবালসিক Final)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -384,6 +384,8 @@
     <string name="subtype_with_layout_bn_BD"><xliff:g id="LANGUAGE_NAME" example="Bengali">%s</xliff:g> (Akkhor)</string>
     <!-- Description for Bengali (Probhat) keyboard subtype with explicit keyboard layout [CHAR LIMIT=25] -->
     <string name="subtype_probhat_bn_BD"><xliff:g id="LANGUAGE_NAME" example="Bengali">%s</xliff:g> (Probhat)</string>
+    <!-- Description for Bengali (Baishakhi) keyboard subtype with explicit keyboard layout [CHAR LIMIT=25] -->
+    <string name="subtype_baishakhi_bn_IN"><xliff:g id="LANGUAGE_NAME" example="Bengali">%s</xliff:g> (Baishakhi)</string>
     <!-- Description for "LANGUAGE_NAME" (Compact) keyboard subtype [CHAR LIMIT=25]
          (Compact) can be an abbreviation to fit in the CHAR LIMIT. -->
     <string name="subtype_generic_compact"><xliff:g id="LANGUAGE_NAME" example="Hindi">%s</xliff:g> (Compact)</string>

--- a/app/src/main/res/xml/method.xml
+++ b/app/src/main/res/xml/method.xml
@@ -21,6 +21,7 @@
     bn_BD: Bengali (Bangladesh)/bengali_unijoy
     bn_BD: Bengali (Bangladesh) (Akkhor)/bengali_akkhor
     bn_IN: Bengali (India)/bengali
+    bn_IN: Bengali (India)/Baishakhi
     ca: Catalan/qwerty+
     cs: Czech/qwertz
     cv: Chuvash/chuvash
@@ -266,6 +267,15 @@
             android:languageTag="bn-IN"
             android:imeSubtypeMode="keyboard"
             android:imeSubtypeExtraValue="KeyboardLayoutSet=MAIN:bengali,NoShiftKey,EmojiCapable"
+            android:isAsciiCapable="false"
+    />
+    <subtype android:icon="@drawable/ic_ime_switcher"
+            android:label="@string/subtype_baishakhi_bn_IN"
+            android:subtypeId="0xa2144c0d"
+            android:imeSubtypeLocale="bn_IN"
+            android:languageTag="bn-IN"
+            android:imeSubtypeMode="keyboard"
+            android:imeSubtypeExtraValue="KeyboardLayoutSet=MAIN:bengali_baishakhi,EmojiCapable"
             android:isAsciiCapable="false"
     />
     <subtype android:icon="@drawable/ic_ime_switcher"


### PR DESCRIPTION
Added Bengali Baishakhi (bn-IN) layout. Adopted the [original layout for PC](https://commons.wikimedia.org/wiki/File:KB-Bengali-Baishakhi.svg) with some minor changes for better compatibility with the phone screen.

<table style="width:100%">
  <tr>
    <td><img src="https://github.com/user-attachments/assets/f851ed1c-4cfd-4046-b203-1b5c7bff312c" width="300"></td>
    <td> <img src="https://github.com/user-attachments/assets/799ca3b7-af2f-4bcb-82e2-9a372f633823" width="300"> </td>
  </tr>
  <tr>
    <td><i>Normal State</i></td>
    <td><i>Shift State</i></td>
  </tr>
</table>

Closes #1371

The Bengali period will be fixed with the PR #1374