### PR TITLE
Improved Probhat Layout

### DIFF
--- a/app/src/main/assets/layouts/main/bengali_probhat.json
+++ b/app/src/main/assets/layouts/main/bengali_probhat.json
@@ -2,135 +2,140 @@
   [
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "ধ" },
-      "default": { "label": "দ" }
+      "default": { "label": "দ", "popup": { "relevant": [{ "label": "ধ" }]}}
     },
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "ঊ" },
-      "default": { "label": "ূ" }
+      "default": { "label": "ূ", "popup": { "relevant": [{ "label": "ঊ" }]}}
     },
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "ঈ" },
-      "default": { "label": "ী" }
+      "default": { "label": "ী", "popup": { "relevant": [{ "label": "ঈ" }]}}
     },
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "ড়" },
-      "default": { "label": "র" }
+      "default": { "label": "র", "popup": { "main": { "label": "ড়" }, "relevant": [{ "label": "র‍্য" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "ঠ", "popup": { "main": { "label": "৳" } } },
-      "default": { "label": "ট" }
+      "manualOrLocked": { "label": "ঠ" },
+      "default": { "label": "ট", "popup": { "relevant": [{ "label": "ঠ" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "ঐ", "popup": { "main": { "label": "ঞ" } } },
-      "default": { "label": "এ" }
+      "manualOrLocked": { "label": "ঐ" },
+      "default": { "label": "এ", "popup": { "relevant": [{ "label": "ঐ" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "উ", "popup": { "main": { "label": "ৎ" } } },
-      "default": { "label": "ু" }
+      "manualOrLocked": { "label": "উ" },
+      "default": { "label": "ু", "popup": { "relevant": [{ "label": "উ" }]}}
     },
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "ই" },
-      "default": { "label": "ি" }
+      "default": { "label": "ি", "popup": { "relevant": [{ "label": "ই" }]}}
     },
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "ঔ" },
-      "default": { "label": "ও" }
+      "default": { "label": "ও", "popup": { "relevant": [{ "label": "ঔ" }]}}
     },
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "ফ" },
-      "default": { "label": "প" }
+      "default": { "label": "প", "popup": { "relevant": [{ "label": "ফ" }]}}
     },
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "ৈ" },
-      "default": { "label": "ে" }
+      "default": { "label": "ে", "popup": { "relevant": [{ "label": "ৈ" }]}}
     }
   ],
   [
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "অ" },
-      "default": { "label": "া" }
+      "default": { "label": "া", "popup": { "relevant": [{ "label": "অ" }]}}
     },
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "ষ" },
-      "default": { "label": "স" }
+      "default": { "label": "স", "popup": { "relevant": [{ "label": "ষ" }]}}
     },
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "ঢ" },
-      "default": { "label": "ড" }
+      "default": { "label": "ড", "popup": { "relevant": [{ "label": "ঢ" }]}}
     },
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "থ" },
-      "default": { "label": "ত" }
+      "default": { "label": "ত", "popup": { "main": { "label": "থ" }, "relevant": [{ "label": "ৎ" }]}}
     },
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "ঘ" },
-      "default": { "label": "গ" }
+      "default": { "label": "গ", "popup": { "relevant": [{ "label": "ঘ" }]}}
     },
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "ঃ" },
-      "default": { "label": "হ" }
+      "default": { "label": "হ", "popup": { "relevant": [{ "label": "ঃ" }]}}
     },
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "ঝ" },
-      "default": { "label": "জ" }
+      "default": { "label": "জ", "popup": { "relevant": [{ "label": "ঝ" }]}}
     },
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "খ" },
-      "default": { "label": "ক" }
+      "default": { "label": "ক", "popup": { "relevant": [{ "label": "খ" }]}}
     },
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "ং" },
-      "default": { "label": "ল" }
+      "default": { "label": "ল", "popup": { "relevant": [{ "label": "ং" }]}}
     },
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "ৌ" },
-      "default": { "label": "ো" }
-    },
-    { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "৳" },
-      "default": { "label": "॥" }
+      "default": { "label": "ো", "popup": { "relevant": [{ "label": "ৌ" }]}}
     }
   ],
   [
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "য" },
-      "default": { "label": "য়" }
+      "default": { "label": "য়", "popup": { "main": { "label": "য" }, "relevant": [{ "label": "্য" }]}}
     },
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "ঢ়" },
-      "default": { "label": "শ" }
+      "default": { "label": "শ", "popup": { "relevant": [{ "label": "ঢ়" }]}}
     },
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "ছ" },
-      "default": { "label": "চ" }
+      "default": { "label": "চ", "popup": { "relevant": [{ "label": "ছ" }]}}
     },
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "ঋ" },
-      "default": { "label": "আ" }
+      "default": { "label": "আ", "popup": { "relevant": [{ "label": "ঋ" }]}}
     },
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "ভ" },
-      "default": { "label": "ব" }
+      "default": { "label": "ব", "popup": { "relevant": [{ "label": "ভ" }]}}
     },
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "ণ" },
-      "default": { "label": "ন" }
+      "default": { "label": "ন", "popup": { "relevant": [{ "label": "ণ" }]}}
     },
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "ঙ" },
-      "default": { "label": "ম" }
+      "default": { "label": "ম", "popup": { "relevant": [{ "label": "ঙ" }]}}
     },
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "ৃ" },
-      "default": { "label": "।" }
+      "default": { "label": "ঞ", "popup": { "relevant": [{ "label": "ৃ" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "ঁ" },
-      "default": { "label": "্" }
+      "manualOrLocked": { "label": "ঁ", "popup": { "relevant": [
+            { "label": "!autoColumnOrder!6"},
+            { "label": "়" },
+            { "label": "ৄ"},
+            { "label": "ঽ"},
+            { "label": "ৢ"},
+            { "label": "ৱ"},
+            { "label": "ৣ"},
+            { "label": "ৗ"},
+            { "label": "ৠ"},
+            { "label": "৺"},
+            { "label": "ঌ"},
+            { "label": "ৰ"},
+            { "label": "ৡ" }]}},
+      "default": { "label": "্", "popup": { "relevant": [{ "label": "ঁ" }]}}
     }
-  ],
-  [
-    { "label": "," },
-    { "label": "." }
   ]
 ]


### PR DESCRIPTION
Discussed in https://github.com/Helium314/HeliBoard/discussions/1368
Previous conversation on Probhat layout: #489

I have revised the Probhat layout based on an analysis of the original [Probhat layout for PC](https://commons.wikimedia.org/wiki/File:KB-Bengali-Probhat.svg), as well as its implementations in [Ridmik Keyboard](https://play.google.com/store/apps/details?id=ridmik.keyboard) and [Indic Keyboard](https://play.google.com/store/apps/details?id=org.smc.inputmethod.indic). 

<table style="width:100%">
  <tr>
    <td><img src="https://github.com/user-attachments/assets/a0c86d6b-ee6e-456d-b34c-5dfee73e3074" width="300"></td>
    <td> <img src="https://github.com/user-attachments/assets/407b02b8-fe95-4195-821a-55b4e9ae8a15" width="300"> </td>
  </tr>
  <tr>
    <td><i>Normal State</i></td>
    <td><i>Shift State</i></td>
  </tr>
</table>

Here are the key justifications for these changes:

**1. Relocating the ` ো` key:**

- Moved to the second row, similar to Indic Keyboard and the [current Probhat layout](https://github.com/Helium314/HeliBoard/blob/main/app/src/main/assets/layouts/main/bengali_probhat.json) in HeliBoard.
- This reduces key density in the first row, making the layout more balanced.


**2. Bengali period `।` placed in the standard position:**

- Moved to replace the Latin period, aligning with the original Probhat layout and Ridmik Keyboard.

**3. Dedicated key for `ঞ` and Placement of `ঞ` and ` ৃ` :**

- In the original Probhat layout, ঞ is on the number row in the Shift state. On mobile, it is currently buried in long-press options, making it harder to access.
- ঞ is frequently used in ligatures such as বিজ্ঞান, গঞ্জ, অঞ্জলি, জ্ঞান, etc. So ঞ requires a dedicated key than a  long-press option.
- A dedicated key improves accessibility.
- On mobile, the comma key is positioned differently from a computer keyboard, freeing up space on the ` ৃ` key.
- I placed ঞ in this available position.
- I am considering whether `ঞ` should be in the normal state and ` ৃ` in Shift, or vice versa. I lean towards placing `ঞ` in the normal state and ` ৃ` in Shift, as `ঞ` is more frequently used and this respects the original position of the ` ৃ` key in Probhat.


**4. Removal of the dedicated `॥` and `৳` key:**

- ॥ is already accessible via long-press on the Bengali period key.
- Since ॥ is rarely used in Bengali, a dedicated key is unnecessary.
- ৳ is already accessible via Symbols Layout.