### PR TITLE
Add label flag to manualOrLocked keys to hide popup hint in Probhat layout

### DIFF
--- a/app/src/main/assets/layouts/main/bengali_probhat.json
+++ b/app/src/main/assets/layouts/main/bengali_probhat.json
@@ -1,123 +1,123 @@
 [
   [
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "ধ" },
+      "manualOrLocked": { "label": "ধ", "labelFlags": 1073741824 },
       "default": { "label": "দ", "popup": { "relevant": [{ "label": "ধ" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "ঊ" },
+      "manualOrLocked": { "label": "ঊ", "labelFlags": 1073741824 },
       "default": { "label": "ূ", "popup": { "relevant": [{ "label": "ঊ" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "ঈ" },
+      "manualOrLocked": { "label": "ঈ", "labelFlags": 1073741824 },
       "default": { "label": "ী", "popup": { "relevant": [{ "label": "ঈ" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "ড়" },
+      "manualOrLocked": { "label": "ড়", "labelFlags": 1073741824 },
       "default": { "label": "র", "popup": { "main": { "label": "ড়" }, "relevant": [{ "label": "র‍্য" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "ঠ" },
+      "manualOrLocked": { "label": "ঠ", "labelFlags": 1073741824 },
       "default": { "label": "ট", "popup": { "relevant": [{ "label": "ঠ" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "ঐ" },
+      "manualOrLocked": { "label": "ঐ", "labelFlags": 1073741824 },
       "default": { "label": "এ", "popup": { "relevant": [{ "label": "ঐ" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "উ" },
+      "manualOrLocked": { "label": "উ", "labelFlags": 1073741824 },
       "default": { "label": "ু", "popup": { "relevant": [{ "label": "উ" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "ই" },
+      "manualOrLocked": { "label": "ই", "labelFlags": 1073741824 },
       "default": { "label": "ি", "popup": { "relevant": [{ "label": "ই" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "ঔ" },
+      "manualOrLocked": { "label": "ঔ", "labelFlags": 1073741824 },
       "default": { "label": "ও", "popup": { "relevant": [{ "label": "ঔ" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "ফ" },
+      "manualOrLocked": { "label": "ফ", "labelFlags": 1073741824 },
       "default": { "label": "প", "popup": { "relevant": [{ "label": "ফ" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "ৈ" },
+      "manualOrLocked": { "label": "ৈ", "labelFlags": 1073741824 },
       "default": { "label": "ে", "popup": { "relevant": [{ "label": "ৈ" }]}}
     }
   ],
   [
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "অ" },
+      "manualOrLocked": { "label": "অ", "labelFlags": 1073741824 },
       "default": { "label": "া", "popup": { "relevant": [{ "label": "অ" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "ষ" },
+      "manualOrLocked": { "label": "ষ", "labelFlags": 1073741824 },
       "default": { "label": "স", "popup": { "relevant": [{ "label": "ষ" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "ঢ" },
+      "manualOrLocked": { "label": "ঢ", "labelFlags": 1073741824 },
       "default": { "label": "ড", "popup": { "relevant": [{ "label": "ঢ" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "থ" },
+      "manualOrLocked": { "label": "থ", "labelFlags": 1073741824 },
       "default": { "label": "ত", "popup": { "main": { "label": "থ" }, "relevant": [{ "label": "ৎ" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "ঘ" },
+      "manualOrLocked": { "label": "ঘ", "labelFlags": 1073741824 },
       "default": { "label": "গ", "popup": { "relevant": [{ "label": "ঘ" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "ঃ" },
+      "manualOrLocked": { "label": "ঃ", "labelFlags": 1073741824 },
       "default": { "label": "হ", "popup": { "relevant": [{ "label": "ঃ" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "ঝ" },
+      "manualOrLocked": { "label": "ঝ", "labelFlags": 1073741824 },
       "default": { "label": "জ", "popup": { "relevant": [{ "label": "ঝ" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "খ" },
+      "manualOrLocked": { "label": "খ", "labelFlags": 1073741824 },
       "default": { "label": "ক", "popup": { "relevant": [{ "label": "খ" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "ং" },
+      "manualOrLocked": { "label": "ং", "labelFlags": 1073741824 },
       "default": { "label": "ল", "popup": { "relevant": [{ "label": "ং" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "ৌ" },
+      "manualOrLocked": { "label": "ৌ", "labelFlags": 1073741824 },
       "default": { "label": "ো", "popup": { "relevant": [{ "label": "ৌ" }]}}
     }
   ],
   [
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "য" },
+      "manualOrLocked": { "label": "য", "labelFlags": 1073741824 },
       "default": { "label": "য়", "popup": { "main": { "label": "য" }, "relevant": [{ "label": "্য" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "ঢ়" },
+      "manualOrLocked": { "label": "ঢ়", "labelFlags": 1073741824 },
       "default": { "label": "শ", "popup": { "relevant": [{ "label": "ঢ়" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "ছ" },
+      "manualOrLocked": { "label": "ছ", "labelFlags": 1073741824 },
       "default": { "label": "চ", "popup": { "relevant": [{ "label": "ছ" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "ঋ" },
+      "manualOrLocked": { "label": "ঋ", "labelFlags": 1073741824 },
       "default": { "label": "আ", "popup": { "relevant": [{ "label": "ঋ" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "ভ" },
+      "manualOrLocked": { "label": "ভ", "labelFlags": 1073741824 },
       "default": { "label": "ব", "popup": { "relevant": [{ "label": "ভ" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "ণ" },
+      "manualOrLocked": { "label": "ণ", "labelFlags": 1073741824 },
       "default": { "label": "ন", "popup": { "relevant": [{ "label": "ণ" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "ঙ" },
+      "manualOrLocked": { "label": "ঙ", "labelFlags": 1073741824 },
       "default": { "label": "ম", "popup": { "relevant": [{ "label": "ঙ" }]}}
     },
     { "$": "shift_state_selector",
-      "manualOrLocked": { "label": "ৃ" },
+      "manualOrLocked": { "label": "ৃ", "labelFlags": 1073741824 },
       "default": { "label": "ঞ", "popup": { "relevant": [{ "label": "ৃ" }]}}
     },
     { "$": "shift_state_selector",


### PR DESCRIPTION
Add a label flag on `manualOrLocked` keys in the Probhat layout to hide the popup hint. Other Bengali layouts also have these to hide non-Bengali popup hints and make the layout look cleaner. This ensures better consistency across Bengali layouts.

 I missed adding this earlier. Apologies for the oversight!