### PR TITLE
Track overridden subtypes when auto-switching due to HintLocales

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/LatinIME.java
+++ b/app/src/main/java/helium314/keyboard/latin/LatinIME.java
@@ -153,12 +153,6 @@ public class LatinIME extends InputMethodService implements
     @Nullable
     private Context mDisplayContext;
 
-    // When HintLocales causes a subtype override, we store
-    // the overridden subtype here in order to restore it when
-    // we switch to another input context that has no HintLocales.
-    @Nullable
-    private InputMethodSubtype mOverriddenByHintLocale;
-
     // Object for reacting to adding/removing a dictionary pack.
     private final BroadcastReceiver mDictionaryPackInstallReceiver =
             new DictionaryPackInstallBroadcastReceiver(this);
@@ -529,11 +523,80 @@ public class LatinIME extends InputMethodService implements
     }
 
     final class SubtypeState {
+        // When HintLocales causes a subtype override, we store
+        // the overridden subtype here in order to restore it when
+        // we switch to another input context that has no HintLocales.
+        private InputMethodSubtype mOverriddenByLocale;
+
         private InputMethodSubtype mLastActiveSubtype;
         private boolean mCurrentSubtypeHasBeenUsed = true; // starting with true avoids immediate switch
 
         public void setCurrentSubtypeHasBeenUsed() {
             mCurrentSubtypeHasBeenUsed = true;
+        }
+
+        // TextFields can provide locale/language hints that the IME should use via 'hintLocales'.
+        // If a matching subtype is found, we temporarily switch to that subtype until
+        // we return to a context that does not provide any hints, or until the user
+        // explicitly changes the language/subtype in use.
+        public InputMethodSubtype getSubtypeForLocales(final RichInputMethodManager richImm, final Iterable<Locale> locales) {
+            final InputMethodSubtype overriddenByLocale = mOverriddenByLocale;
+            if (locales == null) {
+                if (overriddenByLocale != null) {
+                    // no locales provided, so switch back to
+                    // whatever subtype was used last time.
+                    mOverriddenByLocale = null;
+
+                    return overriddenByLocale;
+                }
+
+                return null;
+            }
+
+            final InputMethodSubtype currentSubtype = richImm.getCurrentSubtype().getRawSubtype();
+            final Locale currentSubtypeLocale = richImm.getCurrentSubtypeLocale();
+            final int minimumMatchLevel = 3; // LocaleUtils.LOCALE_LANGUAGE_MATCH_COUNTRY_DIFFER;
+
+            // Try finding a subtype matching the hint language.
+            for (final Locale hintLocale : locales) {
+                if (LocaleUtils.INSTANCE.getMatchLevel(hintLocale, currentSubtypeLocale) >= minimumMatchLevel
+                        || CollectionsKt.any(mSettings.getCurrent().mSecondaryLocales,
+                            (secLocale) -> LocaleUtils.INSTANCE.getMatchLevel(hintLocale, secLocale) >= minimumMatchLevel)) {
+                    // current locales are already a good match, and we want to avoid unnecessary layout switches.
+                    return null;
+                }
+
+                final InputMethodSubtype subtypeForHintLocale = richImm.findSubtypeForHintLocale(hintLocale);
+                if (subtypeForHintLocale == null) {
+                    continue;
+                }
+
+                if (subtypeForHintLocale.equals(currentSubtype)) {
+                    // no need to switch, we already use the correct locale.
+                    return null;
+                }
+
+                if (overriddenByLocale == null) {
+                    // auto-switching based on hint locale, so store
+                    // whatever subtype was in use so we can switch back
+                    // to it later when there are no hint locales.
+                    mOverriddenByLocale = currentSubtype;
+                }
+
+                return subtypeForHintLocale;
+            }
+
+            return null;
+        }
+
+        public void onSubtypeChanged(final InputMethodSubtype oldSubtype,
+                                     final InputMethodSubtype newSubtype) {
+            if (oldSubtype != mOverriddenByLocale) {
+                // Whenever the subtype is changed, clear tracking
+                // the subtype that is overridden by a HintLocale as
+                // we no longer have a subtype to automatically switch back to.
+                mOverriddenByLocale = null;
+            }
         }
 
         public void switchSubtype(final RichInputMethodManager richImm) {
@@ -865,12 +928,7 @@ public class LatinIME extends InputMethodService implements
         }
         InputMethodSubtype oldSubtype = mRichImm.getCurrentSubtype().getRawSubtype();
 
-        if (mOverriddenByHintLocale != oldSubtype) {
-            // Clear tracking the subtype that is overridden by a HintLocale
-            // when subtypes are changed in any way other than the initial automatic change.
-            mOverriddenByHintLocale = null;
-        }
-
+        mSubtypeState.onSubtypeChanged(oldSubtype, subtype);
         StatsUtils.onSubtypeChanged(oldSubtype, subtype);
         mRichImm.onSubtypeChanged(subtype);
         mInputLogic.onSubtypeChanged(SubtypeLocaleUtils.getCombiningRulesExtraValue(subtype),
@@ -889,28 +947,10 @@ public class LatinIME extends InputMethodService implements
         super.onStartInput(editorInfo, restarting);
 
         final List<Locale> hintLocales = EditorInfoCompatUtils.getHintLocales(editorInfo);
-        if (hintLocales == null) {
-            if (mOverriddenByHintLocale != null) {
-                mHandler.postSwitchLanguage(mOverriddenByHintLocale);
-                mOverriddenByHintLocale = null;
-            }
-            return;
-        }
-        // Try switching to a subtype matching the hint language.
-        for (final Locale hintLocale : hintLocales) {
-            if (LocaleUtils.INSTANCE.getMatchLevel(hintLocale, mRichImm.getCurrentSubtypeLocale()) >= 3
-                    || CollectionsKt.any(mSettings.getCurrent().mSecondaryLocales, (secLocale) -> LocaleUtils.INSTANCE.getMatchLevel(hintLocale, secLocale) >= 3))
-                return; // current locales are already a good match, and we want to avoid unnecessary layout switches
-            final InputMethodSubtype newSubtype = mRichImm.findSubtypeForHintLocale(hintLocale);
-            if (newSubtype == null) continue;
-            if (newSubtype.equals(mRichImm.getCurrentSubtype().getRawSubtype()))
-                return; // no need to switch, we already use the correct locale
-
-            if (mOverriddenByHintLocale == null) {
-                mOverriddenByHintLocale = mRichImm.getCurrentSubtype().getRawSubtype();
-            }
-            mHandler.postSwitchLanguage(newSubtype);
-            break;
+        final InputMethodSubtype subtypeForLocales = mSubtypeState.getSubtypeForLocales(mRichImm, hintLocales);
+        if (subtypeForLocales != null) {
+            // found a better subtype using hint locales that we should switch to.
+            mHandler.postSwitchLanguage(subtypeForLocales);
         }
     }
 


### PR DESCRIPTION
Fixes [#1409](https://github.com/Helium314/HeliBoard/issues/1409)

This has to do with `keyboardOptions.hintLocales` (e.g., in TextFields) causing input languages (subtypes) to be automatically changed. This change tracks the subtype being overridden by a HintLocale so that it can gracefully reset when the HintLocale is no longer being applied.

If the user switches languages after a HintLocale is applied, the overridden subtype is cleared so that the new language will stick until a new HintLocale is applied again.

A possible limitation unresolved by this PR is that a HintLocale will always override when first encountered, so if you manually switch to something else and go to another app then come back, it will clear your selection.