### PR TITLE
Fix bottom inset padding on Android15+, take 3

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardView.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardView.java
@@ -148,8 +148,6 @@ public class KeyboardView extends View {
 
         mPaint.setAntiAlias(true);
         mTypeface = Settings.getInstance().getCustomTypeface();
-
-        setFitsSystemWindows(true);
     }
 
     @Nullable

--- a/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardHistoryView.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardHistoryView.kt
@@ -71,7 +71,6 @@ class ClipboardHistoryView @JvmOverloads constructor(
         getEnabledClipboardToolbarKeys(context.prefs())
             .forEach { toolbarKeys.add(createToolbarKey(context, KeyboardIconsSet.instance, it)) }
         keyboardAttr.recycle()
-        fitsSystemWindows = true
     }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {

--- a/app/src/main/java/helium314/keyboard/keyboard/emoji/EmojiPalettesView.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/emoji/EmojiPalettesView.java
@@ -106,7 +106,6 @@ public final class EmojiPalettesView extends LinearLayout
                 R.styleable.EmojiPalettesView_categoryPageIndicatorColor, 0);
         emojiPalettesViewAttr.recycle();
         mEmojiLayoutManager = new LinearLayoutManager(context, LinearLayoutManager.VERTICAL, false);
-        setFitsSystemWindows(true);
     }
 
     @Override

--- a/app/src/main/java/helium314/keyboard/latin/InputView.java
+++ b/app/src/main/java/helium314/keyboard/latin/InputView.java
@@ -26,6 +26,8 @@ import helium314.keyboard.latin.common.ColorType;
 import helium314.keyboard.latin.settings.Settings;
 import helium314.keyboard.latin.suggestions.PopupSuggestionsView;
 import helium314.keyboard.latin.suggestions.SuggestionStripView;
+import kotlin.Unit;
+
 
 public final class InputView extends FrameLayout {
     private static final int[] LOCATION = new int[2];
@@ -50,10 +52,7 @@ public final class InputView extends FrameLayout {
                 mMainKeyboardView, suggestionStripView);
         mMoreSuggestionsViewCanceler = new MoreSuggestionsViewCanceler(
                 mMainKeyboardView, suggestionStripView);
-        ViewKt.doOnNextLayout(this, v -> {
-            Settings.getValues().mColors.setBackground(findViewById(R.id.main_keyboard_frame), ColorType.MAIN_BACKGROUND);
-            return null;
-        });
+        ViewKt.doOnNextLayout(this, this::onNextLayout);
     }
 
     public void setKeyboardTopPadding(final int keyboardTopPadding) {
@@ -69,27 +68,6 @@ public final class InputView extends FrameLayout {
             return true;
         }
         return super.dispatchHoverEvent(event);
-    }
-
-    @Override
-    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
-        super.onLayout(changed, left, top, right, bottom);
-
-        if (Build.VERSION.SDK_INT >= 30) {
-            getLocationOnScreen(LOCATION);
-            if (LOCATION[1] + getHeight() == getDisplay().getHeight()) {
-                WindowManager wm = getContext().getSystemService(WindowManager.class);
-                WindowMetrics windowMetrics = wm.getCurrentWindowMetrics();
-                WindowInsets windowInsets = windowMetrics.getWindowInsets();
-                int insetTypes = WindowInsets.Type.systemBars() | WindowInsets.Type.displayCutout();
-                Insets insets = windowInsets.getInsetsIgnoringVisibility(insetTypes);
-
-                // Can't set padding on this view, since it results in an overlap with window above the keyboard.
-                mMainKeyboardView.setPadding(0, 0, 0, insets.bottom);
-                findViewById(R.id.emoji_palettes_view).setPadding(0, 0, 0, insets.bottom);
-                findViewById(R.id.clipboard_history_view).setPadding(0, 0, 0, insets.bottom);
-            }
-        }
     }
 
     @Override
@@ -130,6 +108,29 @@ public final class InputView extends FrameLayout {
         final int x = (int)me.getX(index) + rect.left;
         final int y = (int)me.getY(index) + rect.top;
         return mActiveForwarder.onTouchEvent(x, y, me);
+    }
+
+    private Unit onNextLayout(View v) {
+        Settings.getValues().mColors.setBackground(findViewById(R.id.main_keyboard_frame), ColorType.MAIN_BACKGROUND);
+
+        if (Build.VERSION.SDK_INT >= 30) {
+            getLocationOnScreen(LOCATION);
+            WindowManager wm = getContext().getSystemService(WindowManager.class);
+            WindowMetrics windowMetrics = wm.getCurrentWindowMetrics();
+            if (LOCATION[1] + getHeight() == windowMetrics.getBounds().height()) {
+                // Edge-to-edge mode
+                WindowInsets windowInsets = windowMetrics.getWindowInsets();
+                int insetTypes = WindowInsets.Type.systemBars() | WindowInsets.Type.displayCutout();
+                Insets insets = windowInsets.getInsetsIgnoringVisibility(insetTypes);
+
+                // Can't set padding on this view, since it results in an overlap with window above the keyboard.
+                mMainKeyboardView.setPadding(0, 0, 0, insets.bottom);
+                findViewById(R.id.emoji_palettes_view).setPadding(0, 0, 0, insets.bottom);
+                findViewById(R.id.clipboard_history_view).setPadding(0, 0, 0, insets.bottom);
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/app/src/main/java/helium314/keyboard/latin/InputView.java
+++ b/app/src/main/java/helium314/keyboard/latin/InputView.java
@@ -7,10 +7,15 @@
 package helium314.keyboard.latin;
 
 import android.content.Context;
+import android.graphics.Insets;
 import android.graphics.Rect;
+import android.os.Build;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.WindowInsets;
+import android.view.WindowManager;
+import android.view.WindowMetrics;
 import android.widget.FrameLayout;
 
 import androidx.core.view.ViewKt;
@@ -23,6 +28,8 @@ import helium314.keyboard.latin.suggestions.PopupSuggestionsView;
 import helium314.keyboard.latin.suggestions.SuggestionStripView;
 
 public final class InputView extends FrameLayout {
+    private static final int[] LOCATION = new int[2];
+
     private final Rect mInputViewRect = new Rect();
     private MainKeyboardView mMainKeyboardView;
     private KeyboardTopPaddingForwarder mKeyboardTopPaddingForwarder;
@@ -62,6 +69,27 @@ public final class InputView extends FrameLayout {
             return true;
         }
         return super.dispatchHoverEvent(event);
+    }
+
+    @Override
+    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+        super.onLayout(changed, left, top, right, bottom);
+
+        if (Build.VERSION.SDK_INT >= 30) {
+            getLocationOnScreen(LOCATION);
+            if (LOCATION[1] + getHeight() == getDisplay().getHeight()) {
+                WindowManager wm = getContext().getSystemService(WindowManager.class);
+                WindowMetrics windowMetrics = wm.getCurrentWindowMetrics();
+                WindowInsets windowInsets = windowMetrics.getWindowInsets();
+                int insetTypes = WindowInsets.Type.systemBars() | WindowInsets.Type.displayCutout();
+                Insets insets = windowInsets.getInsetsIgnoringVisibility(insetTypes);
+
+                // Can't set padding on this view, since it results in an overlap with window above the keyboard.
+                mMainKeyboardView.setPadding(0, 0, 0, insets.bottom);
+                findViewById(R.id.emoji_palettes_view).setPadding(0, 0, 0, insets.bottom);
+                findViewById(R.id.clipboard_history_view).setPadding(0, 0, 0, insets.bottom);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
This is a continuation of #1461, fixing https://github.com/Helium314/HeliBoard/pull/1461#issuecomment-2811585813. I tried to use `ViewCompat.setOnApplyWindowInsetsListener`, and found that the listener is not called reliably, just like `setFitsSystemWindows`.

This solution is not pretty, but it's the only one that I found to work reliably with and without edge-to-edge enforcement, without checking for SDK35 explicitly.
