### PR TITLE
Add korean phonetic layout- easiest korean input in qwerty style

### DIFF
--- a/app/src/main/assets/layouts/main/korean_phonetic.json
+++ b/app/src/main/assets/layouts/main/korean_phonetic.json
@@ -2,12 +2,12 @@
   [
     { "label": "\u3147" },
     { "label": "\u3161" },
-	{ "$": "shift_state_selector",
+    { "$": "shift_state_selector",
       "manualOrLocked": { "label": "\u3156" },
       "default": { "label": "\u3154", "popup": { "main": { "label": "\u3156" } } }
-    },	
-	{ "label": "\u3139" },
-    { "label": "\u314c" },		
+    },
+    { "label": "\u3139" },
+    { "label": "\u314c" },
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "\u3152" },
       "default": { "label": "\u3150", "popup": { "main": { "label": "\u3152" } } }
@@ -22,12 +22,12 @@
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "\u3146" },
       "default": { "label": "\u3145", "popup": { "main": { "label": "\u3146" } } }
-    },	
+    },
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "\u3138" },
       "default": { "label": "\u3137", "popup": { "main": { "label": "\u3138" } } }
-    },	
-    { "label": "\u3151" },	
+    },
+    { "label": "\u3151" },
     { "$": "shift_state_selector",
       "manualOrLocked": { "label": "\u3132" },
       "default": { "label": "\u3131", "popup": { "main": { "label": "\u3132" } } }
@@ -45,7 +45,7 @@
     { "label": "\u3160" },
     { "label": "\u314a" },
     { "label": "\u3153" },
- { "$": "shift_state_selector",
+    { "$": "shift_state_selector",
       "manualOrLocked": { "label": "\u3143" },
       "default": { "label": "\u3142", "popup": { "main": { "label": "\u3143" } } }
     },

--- a/app/src/main/assets/layouts/main/korean_phonetic.json
+++ b/app/src/main/assets/layouts/main/korean_phonetic.json
@@ -1,0 +1,55 @@
+[
+  [
+    { "label": "\u3147" },
+    { "label": "\u3161" },
+	{ "$": "shift_state_selector",
+      "manualOrLocked": { "label": "\u3156" },
+      "default": { "label": "\u3154", "popup": { "main": { "label": "\u3156" } } }
+    },	
+	{ "label": "\u3139" },
+    { "label": "\u314c" },		
+    { "$": "shift_state_selector",
+      "manualOrLocked": { "label": "\u3152" },
+      "default": { "label": "\u3150", "popup": { "main": { "label": "\u3152" } } }
+    },
+    { "label": "\u315c" },
+    { "label": "\u3163" },
+    { "label": "\u3157" },
+    { "label": "\u314d" }
+  ],
+  [
+    { "label": "\u314f" },
+    { "$": "shift_state_selector",
+      "manualOrLocked": { "label": "\u3146" },
+      "default": { "label": "\u3145", "popup": { "main": { "label": "\u3146" } } }
+    },	
+    { "$": "shift_state_selector",
+      "manualOrLocked": { "label": "\u3138" },
+      "default": { "label": "\u3137", "popup": { "main": { "label": "\u3138" } } }
+    },	
+    { "label": "\u3151" },	
+    { "$": "shift_state_selector",
+      "manualOrLocked": { "label": "\u3132" },
+      "default": { "label": "\u3131", "popup": { "main": { "label": "\u3132" } } }
+    },
+    { "label": "\u314e" },
+    { "$": "shift_state_selector",
+      "manualOrLocked": { "label": "\u3149" },
+      "default": { "label": "\u3148", "popup": { "main": { "label": "\u3149" } } }
+    },
+    { "label": "\u314b" },
+    { "label": "\u315b" }
+  ],
+  [
+    { "label": "\u3155" },
+    { "label": "\u3160" },
+    { "label": "\u314a" },
+    { "label": "\u3153" },
+ { "$": "shift_state_selector",
+      "manualOrLocked": { "label": "\u3143" },
+      "default": { "label": "\u3142", "popup": { "main": { "label": "\u3143" } } }
+    },
+    { "label": "\u3134" },
+    { "label": "\u3141" }
+  ]
+]

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -412,8 +412,6 @@
     <!-- Description for "LANGUAGE_NAME" (Phonetic) keyboard subtype -->
     <string name="subtype_generic_phonetic"><xliff:g id="LANGUAGE_NAME" example="Hindi">%s</xliff:g> (Phonetic)</string>
     <!-- Description for "LANGUAGE_NAME" (Sebeolsik 390) keyboard subtype -->
-    <string name="subtype_generic_phonetic"><xliff:g id="LANGUAGE_NAME" example="Korean">%s</xliff:g> (Phonetic)</string>
-    <!-- Description for "LANGUAGE_NAME" (Phonetic) keyboard subtype -->
     <string name="subtype_generic_sebeolsik_390"><xliff:g id="LANGUAGE_NAME" example="Korean">%s</xliff:g> (Sebeolsik 390)</string>
     <!-- Description for "LANGUAGE_NAME" (Sebeolsik Final) keyboard subtype -->
     <string name="subtype_generic_sebeolsik_final"><xliff:g id="LANGUAGE_NAME" example="Korean">%s</xliff:g> (Sebeolsik Final)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -412,6 +412,8 @@
     <!-- Description for "LANGUAGE_NAME" (Phonetic) keyboard subtype -->
     <string name="subtype_generic_phonetic"><xliff:g id="LANGUAGE_NAME" example="Hindi">%s</xliff:g> (Phonetic)</string>
     <!-- Description for "LANGUAGE_NAME" (Sebeolsik 390) keyboard subtype -->
+    <string name="subtype_generic_phonetic"><xliff:g id="LANGUAGE_NAME" example="Korean">%s</xliff:g> (Phonetic)</string>
+    <!-- Description for "LANGUAGE_NAME" (Phonetic) keyboard subtype -->
     <string name="subtype_generic_sebeolsik_390"><xliff:g id="LANGUAGE_NAME" example="Korean">%s</xliff:g> (Sebeolsik 390)</string>
     <!-- Description for "LANGUAGE_NAME" (Sebeolsik Final) keyboard subtype -->
     <string name="subtype_generic_sebeolsik_final"><xliff:g id="LANGUAGE_NAME" example="Korean">%s</xliff:g> (Sebeolsik Final)</string>

--- a/app/src/main/res/xml/method.xml
+++ b/app/src/main/res/xml/method.xml
@@ -55,7 +55,6 @@
     gl_ES: Galician (Spain)/qwerty+
     gu: Gujarati/gujarati
     ha: Hausa/hausa # This is a preliminary keyboard layout.
-	hc: Hcesar/hcesar
     hi: Hindi/hindi
     hi: Hindi/hindi_compact
     hi: Hindi/hindi_phonetic
@@ -555,15 +554,6 @@
             android:imeSubtypeExtraValue="KeyboardLayoutSet=MAIN:hausa,AsciiCapable,EmojiCapable"
             android:isAsciiCapable="true"
     />	 
-   <subtype android:icon="@drawable/ic_ime_switcher"
-            android:label="@string/subtype_generic"
-            android:subtypeId="0x1ec2c969"
-            android:imeSubtypeLocale="hc"
-            android:languageTag="pt"
-            android:imeSubtypeMode="keyboard"
-            android:imeSubtypeExtraValue="KeyboardLayoutSet=MAIN:hc,AsciiCapable,EmojiCapable"
-            android:isAsciiCapable="true"
-	/>
         <subtype android:icon="@drawable/ic_ime_switcher"
             android:label="@string/subtype_generic"
             android:subtypeId="0x39753b7f"

--- a/app/src/main/res/xml/method.xml
+++ b/app/src/main/res/xml/method.xml
@@ -553,7 +553,7 @@
             android:imeSubtypeMode="keyboard"
             android:imeSubtypeExtraValue="KeyboardLayoutSet=MAIN:hausa,AsciiCapable,EmojiCapable"
             android:isAsciiCapable="true"
-    />	 
+    />
         <subtype android:icon="@drawable/ic_ime_switcher"
             android:label="@string/subtype_generic"
             android:subtypeId="0x39753b7f"
@@ -768,7 +768,7 @@
     />
 	<subtype android:icon="@drawable/ic_ime_switcher"
             android:label="@string/subtype_generic"
-            android:subtypeId="0x456d04f2"
+            android:subtypeId="0x3f5a9c12"
             android:imeSubtypeLocale="ko"
             android:languageTag="ko"
             android:imeSubtypeMode="keyboard"

--- a/app/src/main/res/xml/method.xml
+++ b/app/src/main/res/xml/method.xml
@@ -767,7 +767,7 @@
             android:isAsciiCapable="false"
     />
 	<subtype android:icon="@drawable/ic_ime_switcher"
-            android:label="@string/subtype_generic"
+            android:label="@string/subtype_generic_phonetic"
             android:subtypeId="0x3f5a9c12"
             android:imeSubtypeLocale="ko"
             android:languageTag="ko"

--- a/app/src/main/res/xml/method.xml
+++ b/app/src/main/res/xml/method.xml
@@ -55,6 +55,7 @@
     gl_ES: Galician (Spain)/qwerty+
     gu: Gujarati/gujarati
     ha: Hausa/hausa # This is a preliminary keyboard layout.
+	hc: Hcesar/hcesar
     hi: Hindi/hindi
     hi: Hindi/hindi_compact
     hi: Hindi/hindi_phonetic
@@ -553,7 +554,16 @@
             android:imeSubtypeMode="keyboard"
             android:imeSubtypeExtraValue="KeyboardLayoutSet=MAIN:hausa,AsciiCapable,EmojiCapable"
             android:isAsciiCapable="true"
-    />
+    />	 
+   <subtype android:icon="@drawable/ic_ime_switcher"
+            android:label="@string/subtype_generic"
+            android:subtypeId="0x1ec2c969"
+            android:imeSubtypeLocale="hc"
+            android:languageTag="pt"
+            android:imeSubtypeMode="keyboard"
+            android:imeSubtypeExtraValue="KeyboardLayoutSet=MAIN:hc,AsciiCapable,EmojiCapable"
+            android:isAsciiCapable="true"
+	/>
         <subtype android:icon="@drawable/ic_ime_switcher"
             android:label="@string/subtype_generic"
             android:subtypeId="0x39753b7f"
@@ -764,6 +774,15 @@
             android:languageTag="ko"
             android:imeSubtypeMode="keyboard"
             android:imeSubtypeExtraValue="KeyboardLayoutSet=MAIN:korean,SupportTouchPositionCorrection,EmojiCapable"
+            android:isAsciiCapable="false"
+    />
+	<subtype android:icon="@drawable/ic_ime_switcher"
+            android:label="@string/subtype_generic"
+            android:subtypeId="0x456d04f2"
+            android:imeSubtypeLocale="ko"
+            android:languageTag="ko"
+            android:imeSubtypeMode="keyboard"
+            android:imeSubtypeExtraValue="KeyboardLayoutSet=MAIN:korean_phonetic,SupportTouchPositionCorrection,EmojiCapable"
             android:isAsciiCapable="false"
     />
     <subtype android:icon="@drawable/ic_ime_switcher"


### PR DESCRIPTION
Hi, Ive read the readme for the guidelines.
- I added korean_phonetic.json to (layouts)
- I added a layout entry to (method.xml)
- And a new string to (strings.xml)  

Im adding korean phonetic layout, easiest korean layout ever
and best korean layout the world. Why? Is faster to type, easier to learn and like QWERTY

You can try in your browser: (full korean ime, in 40kb)
https://krbord.github.io/romaja/

More information:
https://help.keyman.com/keyboard/korean_phonetic
https://namu.wiki/w/두벌식/자판%20종류#s-2.6

It looks like this:
![Captura de ecrã 2025-04-23 151552](https://github.com/user-attachments/assets/a39fbf68-0a9f-4719-a85d-64f7be720997)
![Captura de ecrã 2025-04-23 151552](https://github.com/user-attachments/assets/42f8e0e6-3a5b-4526-b555-53a157f307e7)
^Shifted

Korean layouts:
https://en.wikipedia.org/wiki/Keyboard_layout#Korean
https://keyman.com/keyboards/languages/ko

Dubeolsik ✅
Sebeolsik - Sebeolsik 390 ✅, Sebeolsik Final ✅
Romaja - SIL, HNC, Gongjin Cheong

Why should this layout be added?
Its the only korean layout like qwerty, in the entire world.
It solves the korean keyboard, that currently is like dvorak (vowels on left)
korean phonetic is the qwerty of korean keyboards!

No need to learn romanizations, as is not a romanization layout.
Is exacly Dubeolsik in every way, just the keys are in (phonetic/qwerty) position.

The keys that are not phonetic, are positioned acording ying-yang:
They are the iotized vowels, ya, yeo, yo, yu.  
ya (ㅑ) and yo (ㅛ) are yang/light vowels - 2nd line
Yeo (ㅕ) and Yu (ㅠ) are Yin/dark vowels - 3rd line


![image](https://github.com/user-attachments/assets/651b67cb-add4-4f9f-8599-75dfa8482369)


There are 26 keys in qwerty layout corresponding to aplhabet. ( 26 letters in keyboard)
18 of them are like romanization, just the ch is on c key. - 70% of layout.
 the ㅇ is on Q and the reason korean is alphabetic syllabary.

so all consonats are placed. that brings the other vowes: 
the ㅡ is on W, as it looks like the ipa symbol ɯ.
the ㅓ is on V, as it looks like the ipa symbol ʌ.
the  ㅐis on Y, as is acombination of ㅏa + ㅣi, like (aɪ) in engish. 
(22/26 keys)

The last 4 vowels, are ㅑon same line as ㅏ, placed 2 keys in distance.
The ㅛ yo is exactly below ㅗ (o), and same like as ㅑ, because of yang.
The ㅕis placed to keys distance of ㅓ, the ㅠ is in same line because of yin.

This layout is easier for foreigns, students, korean learners.

**TL;DR:** Korean layout in qwerty style - phonetic layout
technically a transliteration, but no romanization (only korean letters)



