### PR TITLE
Use the euro sign for PMS

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/internal/keyboard_parser/LocaleKeyboardInfos.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/keyboard_parser/LocaleKeyboardInfos.kt
@@ -264,7 +264,7 @@ private fun getCurrencyKey(locale: Locale): Pair<String, List<String>> {
         return euro
     if (locale.toString().matches(euroLocales))
         return euro
-    if (locale.language.matches("ca|eu|lb|mt".toRegex()))
+    if (locale.language.matches("ca|eu|lb|mt|pms".toRegex()))
         return euro
     if (locale.language.matches("ak|dag|ee|fa|gaa|ha|ig|iw|lo|ko|km|mn|ne|si|th|uk|vi|yo".toRegex()))
         return genericCurrencyKey(getCurrency(locale))


### PR DESCRIPTION
The piedmontese language is a local language of Italy, as such it should display € as the main currency sign instead of the fallback $.

Add the pms locale to the ones used for €.