### PR TITLE
Add hcesar layout - portuguese language

### DIFF
--- a/app/src/main/assets/layouts/main/hcesar.json
+++ b/app/src/main/assets/layouts/main/hcesar.json
@@ -1,0 +1,45 @@
+[
+  [
+    { "label": "h" },
+    { "label": "c" },
+    { "label": "e" },
+    { "label": "s" },
+    { "label": "a" },
+    { "label": "r" },
+    { "label": "o" },
+    { "label": "p" },
+    { "label": "z" },
+    { "$": "shift_state_selector",
+      "shifted": { "label": "«" },
+      "default": { "label": "," }
+}
+  ],
+  [
+    { "label": "q" },
+    { "label": "t" },
+    { "label": "d" },
+    { "label": "i" },
+    { "label": "n" },
+    { "label": "u" },
+    { "label": "l" },
+    { "label": "m" },
+    { "label": "x" },
+    { "$": "shift_state_selector",
+      "shifted": { "label": "»" },
+      "default": { "label": "." }
+}
+  ],
+  [
+    { "label": "ç" },
+    { "label": "j" },
+    { "label": "b" },
+    { "label": "f" },
+    { "label": "v" },
+    { "label": "g" },
+    { "label": "k" }
+  ],
+  [
+    { "label": "y" },
+    { "label": "w" }
+  ]
+]

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -43,6 +43,7 @@
         <item>qwertz</item>
         <item>azerty</item>
         <item>dvorak</item>
+        <item>hcesar</item>		
         <item>halmak</item>
         <item>colemak</item>
         <item>colemak_dh</item>
@@ -57,6 +58,7 @@
         <item>AZERTY</item>
         <item>Dvorak</item>
         <item>Halmak</item>
+        <item>Hcesar</item>
         <item>Colemak</item>
         <item>Colemak Mod-DH</item>
         <item>Workman</item>


### PR DESCRIPTION
Add hcesar layout for Portuguese language (Portugal/Brazil).
![image](https://github.com/user-attachments/assets/e2ca75ca-b073-4d67-8cab-e55d00265b7a)


