### PR TITLE
Fix direction of word-left & word-right with RTL scripts

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/RichInputMethodSubtype.kt
+++ b/app/src/main/java/helium314/keyboard/latin/RichInputMethodSubtype.kt
@@ -10,10 +10,10 @@ import android.view.inputmethod.InputMethodSubtype.InputMethodSubtypeBuilder
 import helium314.keyboard.latin.common.Constants
 import helium314.keyboard.latin.common.Constants.Subtype.ExtraValue.KEYBOARD_LAYOUT_SET
 import helium314.keyboard.latin.common.LocaleUtils.constructLocale
-import helium314.keyboard.latin.common.LocaleUtils.isRtlLanguage
 import helium314.keyboard.latin.utils.LayoutType
 import helium314.keyboard.latin.utils.LayoutUtilsCustom
 import helium314.keyboard.latin.utils.Log
+import helium314.keyboard.latin.utils.ScriptUtils
 import helium314.keyboard.latin.utils.SubtypeLocaleUtils
 import helium314.keyboard.latin.utils.locale
 import java.util.Locale
@@ -25,7 +25,7 @@ class RichInputMethodSubtype private constructor(val rawSubtype: InputMethodSubt
     val locale: Locale = rawSubtype.locale()
 
     // The subtype is considered RTL if the language of the main subtype is RTL.
-    val isRtlSubtype: Boolean = isRtlLanguage(locale)
+    val isRtlSubtype: Boolean = ScriptUtils.isScriptRtl(locale.script)
 
     fun getExtraValueOf(key: String): String? = rawSubtype.getExtraValueOf(key)
 

--- a/app/src/main/java/helium314/keyboard/latin/RichInputMethodSubtype.kt
+++ b/app/src/main/java/helium314/keyboard/latin/RichInputMethodSubtype.kt
@@ -14,6 +14,7 @@ import helium314.keyboard.latin.utils.LayoutType
 import helium314.keyboard.latin.utils.LayoutUtilsCustom
 import helium314.keyboard.latin.utils.Log
 import helium314.keyboard.latin.utils.ScriptUtils
+import helium314.keyboard.latin.utils.ScriptUtils.script
 import helium314.keyboard.latin.utils.SubtypeLocaleUtils
 import helium314.keyboard.latin.utils.locale
 import java.util.Locale
@@ -25,7 +26,7 @@ class RichInputMethodSubtype private constructor(val rawSubtype: InputMethodSubt
     val locale: Locale = rawSubtype.locale()
 
     // The subtype is considered RTL if the language of the main subtype is RTL.
-    val isRtlSubtype: Boolean = ScriptUtils.isScriptRtl(locale.script)
+    val isRtlSubtype: Boolean = ScriptUtils.isScriptRtl(locale.script())
 
     fun getExtraValueOf(key: String): String? = rawSubtype.getExtraValueOf(key)
 

--- a/app/src/main/java/helium314/keyboard/latin/common/LocaleUtils.kt
+++ b/app/src/main/java/helium314/keyboard/latin/common/LocaleUtils.kt
@@ -171,16 +171,6 @@ object LocaleUtils {
         }
     }
 
-    @JvmStatic
-    fun isRtlLanguage(locale: Locale): Boolean {
-        val displayName = locale.getDisplayName(locale)
-        if (displayName.isEmpty()) return false
-        return when (Character.getDirectionality(displayName.codePointAt(0))) {
-            Character.DIRECTIONALITY_RIGHT_TO_LEFT, Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC -> true
-            else -> false
-        }
-    }
-
     fun Locale.localizedDisplayName(context: Context) =
         getLocaleDisplayNameInLocale(this, context.resources, context.resources.configuration.locale())
 

--- a/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
@@ -765,10 +765,12 @@ public final class InputLogic {
                 }
                 break;
             case KeyCode.WORD_LEFT:
-                sendDownUpKeyEventWithMetaState(KeyEvent.KEYCODE_DPAD_LEFT, KeyEvent.META_CTRL_ON);
+                sendDownUpKeyEventWithMetaState(ScriptUtils.isScriptRtl(currentKeyboardScript)?
+                                     KeyEvent.KEYCODE_DPAD_RIGHT : KeyEvent.KEYCODE_DPAD_LEFT, KeyEvent.META_CTRL_ON);
                 break;
             case KeyCode.WORD_RIGHT:
-                sendDownUpKeyEventWithMetaState(KeyEvent.KEYCODE_DPAD_RIGHT, KeyEvent.META_CTRL_ON);
+                sendDownUpKeyEventWithMetaState(ScriptUtils.isScriptRtl(currentKeyboardScript)?
+                                     KeyEvent.KEYCODE_DPAD_LEFT : KeyEvent.KEYCODE_DPAD_RIGHT, KeyEvent.META_CTRL_ON);
                 break;
             case KeyCode.MOVE_START_OF_PAGE:
                 sendDownUpKeyEventWithMetaState(KeyEvent.KEYCODE_MOVE_HOME, KeyEvent.META_CTRL_ON);

--- a/app/src/main/java/helium314/keyboard/latin/utils/ScriptUtils.kt
+++ b/app/src/main/java/helium314/keyboard/latin/utils/ScriptUtils.kt
@@ -184,4 +184,12 @@ object ScriptUtils {
             else -> SCRIPT_LATIN // use as fallback
         }
     }
+
+    @JvmStatic
+    fun isScriptRtl(script: String): Boolean {
+        return when (script) {
+            SCRIPT_ARABIC, SCRIPT_HEBREW -> true
+            else -> false
+        }
+    }
 }


### PR DESCRIPTION
I tried to use character directionality, but that proved problematic at word edges. Using script directionality seems more reliable.

Fixes #979.
