### PR TITLE
Adjust emoji key size according to emoji font size

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardView.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardView.java
@@ -193,7 +193,8 @@ public class KeyboardView extends View {
         invalidateAllKeys();
         requestLayout();
         mFontSizeMultiplier = mKeyboard.mId.isEmojiKeyboard()
-                ? 1
+                // In the case of EmojiKeyFit, the size of emojis is taken care of by the size of the keys
+                ? Settings.getValues().mEmojiKeyFit? 1 : Settings.getValues().mFontSizeMultiplierEmoji
                 : Settings.getValues().mFontSizeMultiplier;
     }
 

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardView.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardView.java
@@ -193,7 +193,7 @@ public class KeyboardView extends View {
         invalidateAllKeys();
         requestLayout();
         mFontSizeMultiplier = mKeyboard.mId.isEmojiKeyboard()
-                ? Settings.getValues().mFontSizeMultiplierEmoji
+                ? 1
                 : Settings.getValues().mFontSizeMultiplier;
     }
 

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardView.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardView.java
@@ -194,7 +194,7 @@ public class KeyboardView extends View {
         requestLayout();
         mFontSizeMultiplier = mKeyboard.mId.isEmojiKeyboard()
                 // In the case of EmojiKeyFit, the size of emojis is taken care of by the size of the keys
-                ? Settings.getValues().mEmojiKeyFit? 1 : Settings.getValues().mFontSizeMultiplierEmoji
+                ? (Settings.getValues().mEmojiKeyFit? 1 : Settings.getValues().mFontSizeMultiplierEmoji)
                 : Settings.getValues().mFontSizeMultiplier;
     }
 

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/keyboard_parser/EmojiParser.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/keyboard_parser/EmojiParser.kt
@@ -44,11 +44,11 @@ class EmojiParser(private val params: KeyboardParams, private val context: Conte
         // this is a bit long, but ensures that emoji size stays the same, independent of these settings
         // we also ignore side padding for key width, and prefer fewer keys per row over narrower keys
         val defaultKeyWidth = ResourceUtils.getDefaultKeyboardWidth(context)  * params.mDefaultKeyWidth
-        val keyWidth = defaultKeyWidth * sqrt(Settings.getValues().mKeyboardHeightScale)
+        val keyWidth = defaultKeyWidth * sqrt(Settings.getValues().mKeyboardHeightScale) * Settings.getValues().mFontSizeMultiplierEmoji
         val defaultKeyboardHeight = ResourceUtils.getDefaultKeyboardHeight(context.resources, false)
         val defaultBottomPadding = context.resources.getFraction(R.fraction.config_keyboard_bottom_padding_holo, defaultKeyboardHeight, defaultKeyboardHeight)
         val emojiKeyboardHeight = ResourceUtils.getDefaultKeyboardHeight(context.resources, false) * 0.75f + params.mVerticalGap - defaultBottomPadding - context.resources.getDimensionPixelSize(R.dimen.config_emoji_category_page_id_height)
-        val keyHeight = emojiKeyboardHeight * params.mDefaultRowHeight * Settings.getValues().mKeyboardHeightScale // still apply height scale to key
+        val keyHeight = emojiKeyboardHeight * params.mDefaultRowHeight * Settings.getValues().mKeyboardHeightScale * Settings.getValues().mFontSizeMultiplierEmoji // still apply height scale to key
 
         emojiArray.forEachIndexed { i, codeArraySpec ->
             val keyParams = parseEmojiKey(codeArraySpec, popupEmojisArray?.get(i)?.takeIf { it.isNotEmpty() }) ?: return@forEachIndexed

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/keyboard_parser/EmojiParser.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/keyboard_parser/EmojiParser.kt
@@ -44,11 +44,17 @@ class EmojiParser(private val params: KeyboardParams, private val context: Conte
         // this is a bit long, but ensures that emoji size stays the same, independent of these settings
         // we also ignore side padding for key width, and prefer fewer keys per row over narrower keys
         val defaultKeyWidth = ResourceUtils.getDefaultKeyboardWidth(context)  * params.mDefaultKeyWidth
-        val keyWidth = defaultKeyWidth * sqrt(Settings.getValues().mKeyboardHeightScale) * Settings.getValues().mFontSizeMultiplierEmoji
+        var keyWidth = defaultKeyWidth * sqrt(Settings.getValues().mKeyboardHeightScale)
         val defaultKeyboardHeight = ResourceUtils.getDefaultKeyboardHeight(context.resources, false)
         val defaultBottomPadding = context.resources.getFraction(R.fraction.config_keyboard_bottom_padding_holo, defaultKeyboardHeight, defaultKeyboardHeight)
         val emojiKeyboardHeight = ResourceUtils.getDefaultKeyboardHeight(context.resources, false) * 0.75f + params.mVerticalGap - defaultBottomPadding - context.resources.getDimensionPixelSize(R.dimen.config_emoji_category_page_id_height)
-        val keyHeight = emojiKeyboardHeight * params.mDefaultRowHeight * Settings.getValues().mKeyboardHeightScale * Settings.getValues().mFontSizeMultiplierEmoji // still apply height scale to key
+        var keyHeight = emojiKeyboardHeight * params.mDefaultRowHeight * Settings.getValues().mKeyboardHeightScale // still apply height scale to key
+
+        if (Settings.getValues().mEmojiKeyFit) {
+            keyWidth *= Settings.getValues().mFontSizeMultiplierEmoji
+            keyHeight *= Settings.getValues().mFontSizeMultiplierEmoji
+        }
+
 
         emojiArray.forEachIndexed { i, codeArraySpec ->
             val keyParams = parseEmojiKey(codeArraySpec, popupEmojisArray?.get(i)?.takeIf { it.isNotEmpty() }) ?: return@forEachIndexed

--- a/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
@@ -89,6 +89,7 @@ object Defaults {
     const val PREF_SIDE_PADDING_SCALE_LANDSCAPE = 0f
     const val PREF_FONT_SCALE = SettingsValues.DEFAULT_SIZE_SCALE
     const val PREF_EMOJI_FONT_SCALE = SettingsValues.DEFAULT_SIZE_SCALE
+    const val PREF_EMOJI_KEY_FIT = false
     const val PREF_SPACE_HORIZONTAL_SWIPE = "move_cursor"
     const val PREF_SPACE_VERTICAL_SWIPE = "none"
     const val PREF_DELETE_SWIPE = true

--- a/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
@@ -89,7 +89,7 @@ object Defaults {
     const val PREF_SIDE_PADDING_SCALE_LANDSCAPE = 0f
     const val PREF_FONT_SCALE = SettingsValues.DEFAULT_SIZE_SCALE
     const val PREF_EMOJI_FONT_SCALE = SettingsValues.DEFAULT_SIZE_SCALE
-    const val PREF_EMOJI_KEY_FIT = false
+    const val PREF_EMOJI_KEY_FIT = true
     const val PREF_SPACE_HORIZONTAL_SWIPE = "move_cursor"
     const val PREF_SPACE_VERTICAL_SWIPE = "none"
     const val PREF_DELETE_SWIPE = true

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -95,6 +95,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_SIDE_PADDING_SCALE_LANDSCAPE = "side_padding_scale_landscape";
     public static final String PREF_FONT_SCALE = "font_scale";
     public static final String PREF_EMOJI_FONT_SCALE = "emoji_font_scale";
+    public static final String PREF_EMOJI_KEY_FIT = "emoji_key_fit";
     public static final String PREF_SPACE_HORIZONTAL_SWIPE = "horizontal_space_swipe";
     public static final String PREF_SPACE_VERTICAL_SWIPE = "vertical_space_swipe";
     public static final String PREF_DELETE_SWIPE = "delete_swipe";

--- a/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
@@ -124,6 +124,7 @@ public class SettingsValues {
     public final String mSpaceBarText;
     public final float mFontSizeMultiplier;
     public final float mFontSizeMultiplierEmoji;
+    public final boolean mEmojiKeyFit;
 
     // From the input box
     @NonNull
@@ -289,6 +290,7 @@ public class SettingsValues {
         mEmojiMaxSdk = prefs.getInt(Settings.PREF_EMOJI_MAX_SDK, Defaults.PREF_EMOJI_MAX_SDK);
         mFontSizeMultiplier = prefs.getFloat(Settings.PREF_FONT_SCALE, Defaults.PREF_FONT_SCALE);
         mFontSizeMultiplierEmoji = prefs.getFloat(Settings.PREF_EMOJI_FONT_SCALE, Defaults.PREF_EMOJI_FONT_SCALE);
+        mEmojiKeyFit = prefs.getBoolean(Settings.PREF_EMOJI_KEY_FIT, Defaults.PREF_EMOJI_KEY_FIT);
     }
 
     public boolean isApplicationSpecifiedCompletionsOn() {

--- a/app/src/main/java/helium314/keyboard/settings/screens/AppearanceScreen.kt
+++ b/app/src/main/java/helium314/keyboard/settings/screens/AppearanceScreen.kt
@@ -84,6 +84,7 @@ fun AppearanceScreen(
         SettingsWithoutKey.CUSTOM_FONT,
         Settings.PREF_FONT_SCALE,
         Settings.PREF_EMOJI_FONT_SCALE,
+        Settings.PREF_EMOJI_KEY_FIT,
     )
     SearchSettingsScreen(
         onClickBack = onClickBack,
@@ -288,6 +289,9 @@ fun createAppearanceSettings(context: Context) = listOf(
             range = 0.5f..1.5f,
             description = { "${(100 * it).toInt()}%" }
         ) { KeyboardSwitcher.getInstance().setThemeNeedsReload() }
+    },
+    Setting(context, Settings.PREF_EMOJI_KEY_FIT, R.string.prefs_emoji_key_fit) {
+        SwitchPreference(it, Defaults.PREF_EMOJI_KEY_FIT) { KeyboardSwitcher.getInstance().setThemeNeedsReload() }
     },
 )
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -348,6 +348,8 @@
     <string name="prefs_font_scale">Keyboard font scale</string>
     <!-- Title of the setting for adjusting font size in emoji view -->
     <string name="prefs_emoji_font_scale">Emoji view font scale</string>
+    <!-- Title of the setting for adjusting emoji key size to fit emoji size in emoji view -->
+    <string name="prefs_emoji_key_fit">Adjust emoji key size to fit emoji size</string>
     <!-- Title of the setting for customizing space bar text -->
     <string name="prefs_space_bar_text">Custom text on space bar</string>
     <!-- Title of the setting for adding / removing custom font file -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -349,7 +349,7 @@
     <!-- Title of the setting for adjusting font size in emoji view -->
     <string name="prefs_emoji_font_scale">Emoji view font scale</string>
     <!-- Title of the setting for adjusting emoji key size to fit emoji size in emoji view -->
-    <string name="prefs_emoji_key_fit">Adjust emoji key size to fit emoji size</string>
+    <string name="prefs_emoji_key_fit">Scale emoji key size with font size</string>
     <!-- Title of the setting for customizing space bar text -->
     <string name="prefs_space_bar_text">Custom text on space bar</string>
     <!-- Title of the setting for adding / removing custom font file -->


### PR DESCRIPTION
This results in showing fewer or more emojis on a page based on the font scale selected. It mostly prevents empty space and overlap between emojis, except at extreme scales, for some reason.

Fixes #516.
