### PR TITLE
Don't show dictionary debug info on toolbar

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripLayoutHelper.java
+++ b/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripLayoutHelper.java
@@ -373,7 +373,7 @@ final class SuggestionStripLayoutHelper {
             x += wordView.getMeasuredWidth();
 
             if (SuggestionStripView.DEBUG_SUGGESTIONS) {
-                layoutDebugInfo(positionInStrip, placerView, x);
+                layoutDebugInfo(positionInStrip, placerView, (int) stripView.getX() + x);
             }
         }
         return startIndexOfMoreSuggestions;
@@ -436,8 +436,7 @@ final class SuggestionStripLayoutHelper {
         placerView.addView(debugInfoView);
         debugInfoView.measure(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
         final int infoWidth = debugInfoView.getMeasuredWidth();
-        final int y = debugInfoView.getMeasuredHeight();
-        ViewLayoutUtils.placeViewAt(debugInfoView, x - infoWidth, y, infoWidth, debugInfoView.getMeasuredHeight());
+        ViewLayoutUtils.placeViewAt(debugInfoView, x - infoWidth, 0, infoWidth, debugInfoView.getMeasuredHeight());
     }
 
     private int getSuggestionWidth(final int positionInStrip, final int maxWidth) {

--- a/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.java
+++ b/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.java
@@ -282,7 +282,7 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
         updateKeys();
         mSuggestedWords = suggestedWords;
         mStartIndexOfMoreSuggestions = mLayoutHelper.layoutAndReturnStartIndexOfMoreSuggestions(
-                getContext(), mSuggestedWords, mSuggestionsStrip, mSuggestionsStrip);
+                getContext(), mSuggestedWords, mSuggestionsStrip, this);
     }
 
     public void setExternalSuggestionView(final View view) {
@@ -486,7 +486,7 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
                 mSuggestedWords.mIsObsoleteSuggestions, mSuggestedWords.mInputStyle,
                 mSuggestedWords.mSequenceNumber);
         mStartIndexOfMoreSuggestions = mLayoutHelper.layoutAndReturnStartIndexOfMoreSuggestions(
-                getContext(), mSuggestedWords, mSuggestionsStrip, mSuggestionsStrip);
+                getContext(), mSuggestedWords, mSuggestionsStrip, this);
         mStripVisibilityGroup.showSuggestionsStrip();
         // Show the toolbar if no suggestions are left and the "Auto show toolbar" setting is enabled
         if (mSuggestedWords.isEmpty() && Settings.getValues().mAutoShowToolbar){
@@ -705,6 +705,13 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
             mSuggestionsStrip.setVisibility(VISIBLE);
             mPinnedKeys.setVisibility(VISIBLE);
         }
+
+        if (DEBUG_SUGGESTIONS) {
+            for (var view : mDebugInfoViews) {
+                view.setVisibility(mSuggestionsStrip.getVisibility());
+            }
+        }
+
         mToolbarExpandKey.setScaleX((visible && !locked ? -1f : 1f) * mRtl);
     }
 

--- a/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.java
+++ b/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.java
@@ -282,7 +282,7 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
         updateKeys();
         mSuggestedWords = suggestedWords;
         mStartIndexOfMoreSuggestions = mLayoutHelper.layoutAndReturnStartIndexOfMoreSuggestions(
-                getContext(), mSuggestedWords, mSuggestionsStrip, this);
+                getContext(), mSuggestedWords, mSuggestionsStrip, mSuggestionsStrip);
     }
 
     public void setExternalSuggestionView(final View view) {
@@ -486,7 +486,7 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
                 mSuggestedWords.mIsObsoleteSuggestions, mSuggestedWords.mInputStyle,
                 mSuggestedWords.mSequenceNumber);
         mStartIndexOfMoreSuggestions = mLayoutHelper.layoutAndReturnStartIndexOfMoreSuggestions(
-                getContext(), mSuggestedWords, mSuggestionsStrip, SuggestionStripView.this);
+                getContext(), mSuggestedWords, mSuggestionsStrip, mSuggestionsStrip);
         mStripVisibilityGroup.showSuggestionsStrip();
         // Show the toolbar if no suggestions are left and the "Auto show toolbar" setting is enabled
         if (mSuggestedWords.isEmpty() && Settings.getValues().mAutoShowToolbar){


### PR DESCRIPTION
Currently, when *Show suggestion infos* is on, the debug info is shown even when suggestions are not, and the toolbar is shown.

This change moves the info strings to the bottom of the keys. Is that ok?