### PR TITLE
Fix unnecessary indentations in the Subtype screen (#1516)

### DIFF
--- a/app/src/main/java/helium314/keyboard/settings/Misc.kt
+++ b/app/src/main/java/helium314/keyboard/settings/Misc.kt
@@ -8,6 +8,9 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.DropdownMenu
@@ -41,6 +44,25 @@ fun WithSmallTitle(
         Text(description, style = MaterialTheme.typography.titleSmall)
         content()
     }
+}
+
+@Composable
+fun ActionRow(
+    modifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null,
+    verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
+    content: @Composable RowScope.() -> Unit
+) {
+    val clickableModifier = if (onClick != null) Modifier.clickable(onClick = onClick)
+    else Modifier
+    Row(
+        modifier = modifier
+            .then(clickableModifier)
+            .fillMaxWidth()
+            .heightIn(min = 44.dp),
+        verticalAlignment = verticalAlignment,
+        content = content
+    )
 }
 
 /** Icon if resource is a vector image, (bitmap) Image otherwise */

--- a/app/src/main/java/helium314/keyboard/settings/screens/SubtypeScreen.kt
+++ b/app/src/main/java/helium314/keyboard/settings/screens/SubtypeScreen.kt
@@ -1,14 +1,12 @@
 package helium314.keyboard.settings.screens
 
 import android.content.Context
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
@@ -74,6 +72,7 @@ import helium314.keyboard.latin.utils.getSecondaryLocales
 import helium314.keyboard.latin.utils.getStringResourceOrName
 import helium314.keyboard.latin.utils.mainLayoutName
 import helium314.keyboard.latin.utils.prefs
+import helium314.keyboard.settings.ActionRow
 import helium314.keyboard.settings.DefaultButton
 import helium314.keyboard.settings.DeleteButton
 import helium314.keyboard.settings.DropDownField
@@ -157,11 +156,7 @@ fun SubtypeScreen(
                 MainLayoutRow(currentSubtype, customMainLayouts) { setCurrentSubtype(it) }
                 if (availableLocalesForScript.size > 1) {
                     WithSmallTitle(stringResource(R.string.secondary_locale)) {
-                        Row(modifier = Modifier
-                            .fillMaxWidth()
-                            .heightIn(min = 44.dp)
-                            .clickable { showSecondaryLocaleDialog = true },
-                            verticalAlignment = Alignment.CenterVertically) {
+                        ActionRow(onClick = { showSecondaryLocaleDialog = true }) {
                             val text = getSecondaryLocales(currentSubtype.extraValues).joinToString(", ") {
                                 it.localizedDisplayName(ctx.resources)
                             }.ifEmpty { stringResource(R.string.action_none) }
@@ -173,29 +168,21 @@ fun SubtypeScreen(
                     }
                 }
                 WithSmallTitle(stringResource(R.string.popup_order_and_hint_source)) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .heightIn(min = 44.dp)
-                            .clickable { showKeyOrderDialog = true },
-                        verticalAlignment = Alignment.CenterVertically) {
-                        Text(stringResource(R.string.popup_order), modifier = Modifier
-                            .weight(1f)
-                            .padding(start = 10.dp)
+                    ActionRow(onClick = { showKeyOrderDialog = true }) {
+                        Text(stringResource(R.string.popup_order),
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(start = 10.dp)
                         )
                         DefaultButton(currentSubtype.getExtraValueOf(ExtraValue.POPUP_ORDER) == null) {
                             setCurrentSubtype(currentSubtype.without(ExtraValue.POPUP_ORDER))
                         }
                     }
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .heightIn(min = 44.dp)
-                            .clickable { showHintOrderDialog = true },
-                        verticalAlignment = Alignment.CenterVertically) {
-                        Text(stringResource(R.string.hint_source), modifier = Modifier
-                            .weight(1f)
-                            .padding(start = 10.dp)
+                    ActionRow(onClick = { showHintOrderDialog = true }) {
+                        Text(stringResource(R.string.hint_source),
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(start = 10.dp)
                         )
                         DefaultButton(currentSubtype.getExtraValueOf(ExtraValue.HINT_ORDER) == null) {
                             setCurrentSubtype(currentSubtype.without(ExtraValue.HINT_ORDER))
@@ -209,14 +196,11 @@ fun SubtypeScreen(
                             Settings.PREF_MORE_POPUP_KEYS,
                             Defaults.PREF_MORE_POPUP_KEYS
                         )!!
-                        Row(modifier = Modifier
-                            .fillMaxWidth()
-                            .heightIn(min = 44.dp)
-                            .clickable { showMorePopupsDialog = true },
-                            verticalAlignment = Alignment.CenterVertically) {
-                            Text(stringResource(morePopupKeysResId(value)), modifier = Modifier
-                                .weight(1f)
-                                .padding(start = 10.dp)
+                        ActionRow(onClick = { showMorePopupsDialog = true }) {
+                            Text(stringResource(morePopupKeysResId(value)),
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .padding(start = 10.dp)
                             )
                             DefaultButton(explicitValue == null) {
                                 setCurrentSubtype(currentSubtype.without(ExtraValue.MORE_POPUPS))
@@ -227,13 +211,11 @@ fun SubtypeScreen(
                 if (hasLocalizedNumberRow(currentSubtype.locale, ctx)) {
                     val checked = currentSubtype.getExtraValueOf(ExtraValue.LOCALIZED_NUMBER_ROW)?.toBoolean()
                     WithSmallTitle(stringResource(R.string.number_row)) {
-                        Row(modifier = Modifier
-                            .fillMaxWidth()
-                            .heightIn(min = 44.dp),
-                            verticalAlignment = Alignment.CenterVertically) {
-                            Text(stringResource(R.string.localized_number_row), modifier = Modifier
-                                .weight(1f)
-                                .padding(start = 10.dp)
+                        ActionRow {
+                            Text(stringResource(R.string.localized_number_row),
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .padding(start = 10.dp)
                             )
                             Switch(
                                 checked = checked ?: prefs.getBoolean(

--- a/app/src/main/java/helium314/keyboard/settings/screens/SubtypeScreen.kt
+++ b/app/src/main/java/helium314/keyboard/settings/screens/SubtypeScreen.kt
@@ -1,12 +1,14 @@
 package helium314.keyboard.settings.screens
 
 import android.content.Context
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
@@ -21,7 +23,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -156,26 +157,49 @@ fun SubtypeScreen(
                 MainLayoutRow(currentSubtype, customMainLayouts) { setCurrentSubtype(it) }
                 if (availableLocalesForScript.size > 1) {
                     WithSmallTitle(stringResource(R.string.secondary_locale)) {
-                        TextButton(onClick = { showSecondaryLocaleDialog = true }) {
+                        Row(modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(min = 44.dp)
+                            .clickable { showSecondaryLocaleDialog = true },
+                            verticalAlignment = Alignment.CenterVertically) {
                             val text = getSecondaryLocales(currentSubtype.extraValues).joinToString(", ") {
                                 it.localizedDisplayName(ctx.resources)
                             }.ifEmpty { stringResource(R.string.action_none) }
-                            Text(text, Modifier.fillMaxWidth())
+                            Text(text, modifier = Modifier
+                                .weight(1f)
+                                .padding(start = 10.dp)
+                            )
                         }
                     }
                 }
-                Row {
-                    TextButton(onClick = { showKeyOrderDialog = true }, Modifier.weight(1f))
-                    { Text(stringResource(R.string.popup_order)) }
-                    DefaultButton(currentSubtype.getExtraValueOf(ExtraValue.POPUP_ORDER) == null) {
-                        setCurrentSubtype(currentSubtype.without(ExtraValue.POPUP_ORDER))
+                WithSmallTitle(stringResource(R.string.popup_order_and_hint_source)) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(min = 44.dp)
+                            .clickable { showKeyOrderDialog = true },
+                        verticalAlignment = Alignment.CenterVertically) {
+                        Text(stringResource(R.string.popup_order), modifier = Modifier
+                            .weight(1f)
+                            .padding(start = 10.dp)
+                        )
+                        DefaultButton(currentSubtype.getExtraValueOf(ExtraValue.POPUP_ORDER) == null) {
+                            setCurrentSubtype(currentSubtype.without(ExtraValue.POPUP_ORDER))
+                        }
                     }
-                }
-                Row {
-                    TextButton(onClick = { showHintOrderDialog = true }, Modifier.weight(1f))
-                    { Text(stringResource(R.string.hint_source)) }
-                    DefaultButton(currentSubtype.getExtraValueOf(ExtraValue.HINT_ORDER) == null) {
-                        setCurrentSubtype(currentSubtype.without(ExtraValue.HINT_ORDER))
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(min = 44.dp)
+                            .clickable { showHintOrderDialog = true },
+                        verticalAlignment = Alignment.CenterVertically) {
+                        Text(stringResource(R.string.hint_source), modifier = Modifier
+                            .weight(1f)
+                            .padding(start = 10.dp)
+                        )
+                        DefaultButton(currentSubtype.getExtraValueOf(ExtraValue.HINT_ORDER) == null) {
+                            setCurrentSubtype(currentSubtype.without(ExtraValue.HINT_ORDER))
+                        }
                     }
                 }
                 if (currentSubtype.locale.script() == ScriptUtils.SCRIPT_LATIN) {
@@ -185,9 +209,15 @@ fun SubtypeScreen(
                             Settings.PREF_MORE_POPUP_KEYS,
                             Defaults.PREF_MORE_POPUP_KEYS
                         )!!
-                        Row {
-                            TextButton(onClick = { showMorePopupsDialog = true }, Modifier.weight(1f))
-                            { Text(stringResource(morePopupKeysResId(value))) }
+                        Row(modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(min = 44.dp)
+                            .clickable { showMorePopupsDialog = true },
+                            verticalAlignment = Alignment.CenterVertically) {
+                            Text(stringResource(morePopupKeysResId(value)), modifier = Modifier
+                                .weight(1f)
+                                .padding(start = 10.dp)
+                            )
                             DefaultButton(explicitValue == null) {
                                 setCurrentSubtype(currentSubtype.without(ExtraValue.MORE_POPUPS))
                             }
@@ -195,20 +225,28 @@ fun SubtypeScreen(
                     }
                 }
                 if (hasLocalizedNumberRow(currentSubtype.locale, ctx)) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        val checked = currentSubtype.getExtraValueOf(ExtraValue.LOCALIZED_NUMBER_ROW)?.toBoolean()
-                        Text(stringResource(R.string.localized_number_row), Modifier.weight(1f))
-                        Switch(
-                            checked = checked ?: prefs.getBoolean(
-                                Settings.PREF_LOCALIZED_NUMBER_ROW,
-                                Defaults.PREF_LOCALIZED_NUMBER_ROW
-                            ),
-                            onCheckedChange = {
-                                setCurrentSubtype(currentSubtype.with(ExtraValue.LOCALIZED_NUMBER_ROW, it.toString()))
+                    val checked = currentSubtype.getExtraValueOf(ExtraValue.LOCALIZED_NUMBER_ROW)?.toBoolean()
+                    WithSmallTitle(stringResource(R.string.number_row)) {
+                        Row(modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(min = 44.dp),
+                            verticalAlignment = Alignment.CenterVertically) {
+                            Text(stringResource(R.string.localized_number_row), modifier = Modifier
+                                .weight(1f)
+                                .padding(start = 10.dp)
+                            )
+                            Switch(
+                                checked = checked ?: prefs.getBoolean(
+                                    Settings.PREF_LOCALIZED_NUMBER_ROW,
+                                    Defaults.PREF_LOCALIZED_NUMBER_ROW
+                                ),
+                                onCheckedChange = {
+                                    setCurrentSubtype(currentSubtype.with(ExtraValue.LOCALIZED_NUMBER_ROW, it.toString()))
+                                }
+                            )
+                            DefaultButton(checked == null) {
+                                setCurrentSubtype(currentSubtype.without(ExtraValue.LOCALIZED_NUMBER_ROW))
                             }
-                        )
-                        DefaultButton(checked == null) {
-                            setCurrentSubtype(currentSubtype.without(ExtraValue.LOCALIZED_NUMBER_ROW))
                         }
                     }
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -205,6 +205,8 @@
     <string name="timestamp_format_title">Format for timestamp key</string>
     <!-- Preferences item for choosing secondary language -->
     <string name="secondary_locale">Multilingual typing</string>
+    <!-- Preferences item to set popup key order and select hints source -->
+    <string name="popup_order_and_hint_source">Popup key order and hints source</string>
     <!-- Clarification which locales are available for multilingual typing -->
     <string name="locales_with_dict">Languages with dictionaries</string>
     <!-- Preferences item for loading an external gesture typing library -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -205,8 +205,6 @@
     <string name="timestamp_format_title">Format for timestamp key</string>
     <!-- Preferences item for choosing secondary language -->
     <string name="secondary_locale">Multilingual typing</string>
-    <!-- Preferences item to set popup key order and select hints source -->
-    <string name="popup_order_and_hint_source">Popup key order and hints source</string>
     <!-- Clarification which locales are available for multilingual typing -->
     <string name="locales_with_dict">Languages with dictionaries</string>
     <!-- Preferences item for loading an external gesture typing library -->
@@ -272,6 +270,8 @@
     <string name="show_hints">Show key hints</string>
     <!-- Description of the settings to show hints -->
     <string name="show_hints_summary">Show long-press hints</string>
+    <!-- Preferences item to set popup key order and select hints source -->
+    <string name="popup_order_and_hint_source">Popup key order and hints source</string>
     <!-- Title of the setting to select key hints source -->
     <string name="hint_source">Select hint source</string>
     <!-- Title of the setting to set popup key order -->


### PR DESCRIPTION
This PR aims to remove indentations in the language subtypes screen (Fixes #1516)

<details>
<summary><b>See screenshot</b></summary>
<br>

| Before | After |
| :------: | :----: |
| <img width=200 src="https://github.com/user-attachments/assets/3e647c7c-d74e-436b-bd36-dadad20bb32e"> | <img width=200 src="https://github.com/user-attachments/assets/4c44dcd2-29b0-437f-a25e-0e48dc2305d4"> |
| <img width=200 src="https://github.com/user-attachments/assets/20c99abb-3a2d-484b-b420-cae015b46d8b"> | <img width=200 src="https://github.com/user-attachments/assets/5c98b1d7-e37f-4ab1-89b4-14c9fb63b60a"> |

</details>

Note: As I am not familiar with Compose, sorry if the written code is incorrectly formatted.