### PR TITLE
Remove non-translatable string

### DIFF
--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -231,7 +231,6 @@
     <string name="hint_source">বোতামের ইঙ্গিতের উৎস</string>
     <string name="popup_order">পপআপ বোতামের ক্রমিক নির্ধারণ</string>
     <string name="popup_keys_number" tools:keep="@string/popup_keys_number">নম্বর সারি</string>
-    <string name="popup_keys_language" tools:keep="@string/popup_keys_language">@string/subtype_locale</string>
     <string name="popup_keys_language_priority" tools:keep="@string/popup_keys_language_priority">ভাষা (অগ্রাধিকার)</string>
     <string name="popup_keys_layout" tools:keep="@string/popup_keys_layout">লেআউট</string>
     <string name="popup_keys_symbols" tools:keep="@string/popup_keys_symbols">প্রতীক</string>


### PR DESCRIPTION
In accordance with https://github.com/Helium314/HeliBoard/commit/e01714bbeeb3842bbdca617e1eb5931230f7cb8a

_Removed here as I was unsure whether the Codeberg translation would be able to remove a read-only string._