### PR TITLE
Slightly adjust the dictionary dialog

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/utils/DictionaryUtils.kt
+++ b/app/src/main/java/helium314/keyboard/latin/utils/DictionaryUtils.kt
@@ -86,7 +86,6 @@ fun MissingDictionaryDialog(onDismissRequest: () -> Unit, locale: Locale) {
 fun createDictionaryTextAnnotated(locale: Locale): AnnotatedString {
     val knownDicts = mutableListOf<Pair<String, String>>()
     val builder = AnnotatedString.Builder()
-    builder.appendLine(stringResource(R.string.dictionary_available))
     val context = LocalContext.current
     context.assets.open("dictionaries_in_dict_repo.csv").reader().forEachLine {
         if (it.isBlank()) return@forEachLine

--- a/app/src/main/java/helium314/keyboard/settings/dialogs/DictionaryDialog.kt
+++ b/app/src/main/java/helium314/keyboard/settings/dialogs/DictionaryDialog.kt
@@ -38,7 +38,6 @@ import helium314.keyboard.settings.DeleteButton
 import helium314.keyboard.settings.ExpandButton
 import helium314.keyboard.settings.Theme
 import helium314.keyboard.settings.dictionaryFilePicker
-import helium314.keyboard.settings.preferences.PreferenceCategory
 import helium314.keyboard.settings.previewDark
 import helium314.keyboard.settings.screens.getUserAndInternalDictionaries
 import java.io.File
@@ -65,19 +64,34 @@ fun DictionaryDialog(
             val state = rememberScrollState()
             Column(Modifier.verticalScroll(state)) {
                 if (hasInternal) {
-                    val color = if (mainDict == null) MaterialTheme.colorScheme.onSurface
+                    val color = if (mainDict == null) MaterialTheme.typography.titleSmall.color
                     else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f) // for disabled look
-                    Text(stringResource(R.string.internal_dictionary_summary), color = color, modifier = Modifier.fillMaxWidth())
+                    val bottomPadding = if (mainDict == null) 12.dp else 0.dp
+                    Text(stringResource(R.string.internal_dictionary_summary),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = bottomPadding),
+                        color = color,
+                        style = MaterialTheme.typography.titleSmall
+                    )
                 }
                 if (mainDict != null)
                     DictionaryDetails(mainDict)
                 if (addonDicts.isNotEmpty()) {
-                    PreferenceCategory(stringResource(R.string.dictionary_category_title))
+                    HorizontalDivider()
+                    Text(stringResource(R.string.dictionary_category_title),
+                        modifier = Modifier.padding(vertical = 12.dp),
+                        style = MaterialTheme.typography.titleSmall
+                    )
                     addonDicts.forEach { DictionaryDetails(it) }
                 }
                 val dictString = createDictionaryTextAnnotated(locale)
                 if (dictString.isNotEmpty()) {
                     HorizontalDivider()
+                    Text(stringResource(R.string.dictionary_available),
+                        modifier = Modifier.padding(top = 12.dp, bottom = 4.dp),
+                        style = MaterialTheme.typography.titleSmall
+                    )
                     Text(dictString, style = LocalTextStyle.current.merge(lineHeight = 1.8.em))
                 }
             }
@@ -113,7 +127,7 @@ private fun DictionaryDetails(dict: File) {
         Text(
             header.info(LocalConfiguration.current.locale()),
             style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.padding(horizontal = 10.dp)
+            modifier = Modifier.padding(start = 10.dp, top = 0.dp, end = 10.dp, bottom = 12.dp)
         )
     }
     if (showDeleteDialog)


### PR DESCRIPTION
This PR allows to slightly adjust the dictionary dialog:
- Remove the unnecessary indentation for the "Add-on dictionaries" title (#1516);
- Slightly adjust some paddings;
- The color of the title "Internal main dictionary" has been slightly adjusted to be consistent with the other titles;


<details>
<summary><b>See screenshots</b></summary>
<br>

| Before | After |
| :------: | :----: |
| <img width=200 src="https://github.com/user-attachments/assets/6d17bad1-1b00-4df9-9d93-b43aaaf78df9"> | <img width=200 src="https://github.com/user-attachments/assets/29863cf5-1685-4826-81e1-266ff7aaa904"> |
| <img width=200 src="https://github.com/user-attachments/assets/d3c32db0-c3ac-4dfe-afe5-f305244d43c4"> | <img width=200 src="https://github.com/user-attachments/assets/33493097-2af4-4e89-b80f-4d610bc0f21f"> |

</details>