### PR TITLE
Add inline emoji search

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/LatinIME.java
+++ b/app/src/main/java/helium314/keyboard/latin/LatinIME.java
@@ -78,6 +78,7 @@ import helium314.keyboard.latin.suggestions.SuggestionStripView;
 import helium314.keyboard.latin.suggestions.SuggestionStripViewAccessor;
 import helium314.keyboard.latin.touchinputconsumer.GestureConsumer;
 import helium314.keyboard.latin.utils.ColorUtilKt;
+import helium314.keyboard.latin.utils.DictionaryInfoUtils;
 import helium314.keyboard.latin.utils.InlineAutofillUtils;
 import helium314.keyboard.latin.utils.InputMethodPickerKt;
 import helium314.keyboard.latin.utils.JniUtils;
@@ -695,6 +696,7 @@ public class LatinIME extends InputMethodService implements
         refreshPersonalizationDictionarySession(currentSettingsValues);
         mInputLogic.mSuggest.clearNextWordSuggestionsCache();
         mStatsUtilsManager.onLoadSettings(this, currentSettingsValues);
+        updateEmojiDictionary();
     }
 
     private void refreshPersonalizationDictionarySession(
@@ -2029,6 +2031,17 @@ public class LatinIME extends InputMethodService implements
         }
         if (Build.VERSION.SDK_INT == Build.VERSION_CODES.S && Build.MANUFACTURER.equals("HUAWEI")) {
             window.setStatusBarColor(Color.TRANSPARENT);
+        }
+    }
+
+    private void updateEmojiDictionary() {
+        if (Settings.getValues().mInlineEmojiSearch) {
+            var locale = mRichImm.getCurrentSubtype().getLocale();
+            var dictFile = DictionaryInfoUtils.getCachedDictForLocaleAndType(locale, "emoji", mDisplayContext);
+            mInputLogic.setEmojiDictionaryFacilitator(dictFile != null?
+                           new SingleDictionaryFacilitator(DictionaryFactory.getDictionary(dictFile, locale)) : null);
+        } else {
+            mInputLogic.setEmojiDictionaryFacilitator(null);
         }
     }
 

--- a/app/src/main/java/helium314/keyboard/latin/RichInputConnection.java
+++ b/app/src/main/java/helium314/keyboard/latin/RichInputConnection.java
@@ -966,9 +966,7 @@ public final class RichInputConnection implements PrivateCommandPerformer {
             consideredCodePoint = 0 == indexOfCodePointInJavaChars ? Constants.NOT_A_CODE
                     : textBeforeCursor.codePointBefore(indexOfCodePointInJavaChars);
         }
-        return !(Constants.NOT_A_CODE == consideredCodePoint
-                || spacingAndPunctuations.isWordSeparator(consideredCodePoint)
-                || spacingAndPunctuations.isWordConnector(consideredCodePoint));
+        return Constants.NOT_A_CODE != consideredCodePoint && spacingAndPunctuations.isWordCodePoint(consideredCodePoint);
     }
 
     public boolean isCursorFollowedByWordCharacter(

--- a/app/src/main/java/helium314/keyboard/latin/Suggest.kt
+++ b/app/src/main/java/helium314/keyboard/latin/Suggest.kt
@@ -121,7 +121,7 @@ class Suggest(private val mDictionaryFacilitator: DictionaryFacilitator) {
         if ((hasAutoCorrection || Settings.getValues().mCenterSuggestionTextToEnter)
             && suggestionsList.size >= indexOfTypedWord && !TextUtils.isEmpty(typedWordString)) {
             if (typedWordFirstOccurrenceWordInfo != null) {
-                if (SuggestionStripView.DEBUG_SUGGESTIONS) addDebugInfo(typedWordFirstOccurrenceWordInfo, typedWordString)
+                addDebugInfo(typedWordFirstOccurrenceWordInfo, typedWordString)
                 suggestionsList.add(indexOfTypedWord, typedWordFirstOccurrenceWordInfo)
             } else {
                 suggestionsList.add(indexOfTypedWord,
@@ -428,7 +428,10 @@ class Suggest(private val mDictionaryFacilitator: DictionaryFacilitator) {
             return suggestionsList
         }
 
-        private fun addDebugInfo(wordInfo: SuggestedWordInfo?, typedWord: String) {
+        @JvmStatic
+        public fun addDebugInfo(wordInfo: SuggestedWordInfo?, typedWord: String) {
+            if (!SuggestionStripView.DEBUG_SUGGESTIONS)
+                return
             val normalizedScore = BinaryDictionaryUtils.calcNormalizedScore(typedWord, wordInfo.toString(), wordInfo!!.mScore)
             val scoreInfoString: String
             val dict = wordInfo.mSourceDict.mDictType + ":" + wordInfo.mSourceDict.mLocale

--- a/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
@@ -57,6 +57,7 @@ object Defaults {
     const val PREF_VIBRATE_ON = false
     const val PREF_VIBRATE_IN_DND_MODE = false
     const val PREF_SOUND_ON = false
+    const val PREF_INLINE_EMOJI_SEARCH = true
     @JvmField
     var PREF_POPUP_ON = true
     const val PREF_AUTO_CORRECTION = true

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -67,6 +67,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_VIBRATE_ON = "vibrate_on";
     public static final String PREF_VIBRATE_IN_DND_MODE = "vibrate_in_dnd_mode";
     public static final String PREF_SOUND_ON = "sound_on";
+    public static final String PREF_INLINE_EMOJI_SEARCH = "inline_emoji_search";
     public static final String PREF_POPUP_ON = "popup_on";
     public static final String PREF_AUTO_CORRECTION = "auto_correction";
     public static final String PREF_MORE_AUTO_CORRECTION = "more_auto_correction";

--- a/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
@@ -56,6 +56,7 @@ public class SettingsValues {
     public final boolean mVibrateOn;
     public final boolean mVibrateInDndMode;
     public final boolean mSoundOn;
+    public final boolean mInlineEmojiSearch;
     public final boolean mKeyPreviewPopupOn;
     public final boolean mShowsVoiceInputKey;
     public final boolean mLanguageSwitchKeyToOtherImes;
@@ -171,6 +172,7 @@ public class SettingsValues {
         mVibrateOn = Settings.readVibrationEnabled(prefs);
         mVibrateInDndMode = prefs.getBoolean(Settings.PREF_VIBRATE_IN_DND_MODE, Defaults.PREF_VIBRATE_IN_DND_MODE);
         mSoundOn = prefs.getBoolean(Settings.PREF_SOUND_ON, Defaults.PREF_SOUND_ON);
+        mInlineEmojiSearch = prefs.getBoolean(Settings.PREF_INLINE_EMOJI_SEARCH, Defaults.PREF_INLINE_EMOJI_SEARCH);
         mKeyPreviewPopupOn = prefs.getBoolean(Settings.PREF_POPUP_ON, Defaults.PREF_POPUP_ON);
         mSlidingKeyInputPreviewEnabled = prefs.getBoolean(
                 DebugSettings.PREF_SLIDING_KEY_INPUT_PREVIEW, Defaults.PREF_SLIDING_KEY_INPUT_PREVIEW);
@@ -303,7 +305,7 @@ public class SettingsValues {
 
     public boolean needsToLookupSuggestions() {
         return (mInputAttributes.mShouldShowSuggestions || mOverrideShowingSuggestions)
-                && (mAutoCorrectEnabled || isSuggestionsEnabledPerUserSettings());
+                && (mAutoCorrectEnabled || mSuggestionsEnabledPerUserSettings);
     }
 
     public boolean isSuggestionsEnabledPerUserSettings() {

--- a/app/src/main/java/helium314/keyboard/latin/utils/DictionaryInfoUtils.kt
+++ b/app/src/main/java/helium314/keyboard/latin/utils/DictionaryInfoUtils.kt
@@ -101,6 +101,16 @@ object DictionaryInfoUtils {
         return absoluteDirectoryName
     }
 
+    @JvmStatic
+    fun getCachedDictForLocaleAndType(locale: Locale, type: String, context: Context): File? {
+        val file = getCachedDictsForLocale(locale, context).firstOrNull { it.name.substringBefore("_") == type }
+        if (file != null) return file
+        if (locale.language != locale.toLanguageTag())
+            return getCachedDictsForLocale(Locale(locale.language), context)
+                .firstOrNull { it.name.substringBefore("_") == type }
+        return null
+    }
+
     fun getCachedDictsForLocale(locale: Locale, context: Context) =
         getCacheDirectoryForLocale(locale, context)?.let { File(it).listFiles() }.orEmpty()
 

--- a/app/src/main/java/helium314/keyboard/latin/utils/TextRange.java
+++ b/app/src/main/java/helium314/keyboard/latin/utils/TextRange.java
@@ -109,4 +109,11 @@ public final class TextRange {
         mHasUrlSpans = hasUrlSpans;
         mWord = mTextAtCursor.subSequence(mWordAtCursorStartIndex, mWordAtCursorEndIndex);
     }
+
+    public Character getCharBeforeWord() {
+        if (mWordAtCursorStartIndex == 0) {
+            return null;
+        }
+        return mTextAtCursor.charAt(mWordAtCursorStartIndex - 1);
+    }
 }

--- a/app/src/main/java/helium314/keyboard/settings/screens/PreferencesScreen.kt
+++ b/app/src/main/java/helium314/keyboard/settings/screens/PreferencesScreen.kt
@@ -55,6 +55,7 @@ fun PreferencesScreen(
         if (prefs.getBoolean(Settings.PREF_VIBRATE_ON, Defaults.PREF_VIBRATE_ON))
             Settings.PREF_VIBRATE_IN_DND_MODE else null,
         Settings.PREF_SOUND_ON,
+        Settings.PREF_INLINE_EMOJI_SEARCH,
         if (prefs.getBoolean(Settings.PREF_SOUND_ON, Defaults.PREF_SOUND_ON))
             Settings.PREF_KEYPRESS_SOUND_VOLUME else null,
         R.string.settings_category_additional_keys,
@@ -110,6 +111,12 @@ fun createPreferencesSettings(context: Context) = listOf(
     },
     Setting(context, Settings.PREF_SOUND_ON, R.string.sound_on_keypress) {
         SwitchPreference(it, Defaults.PREF_SOUND_ON)
+    },
+    Setting(
+        context, Settings.PREF_INLINE_EMOJI_SEARCH, R.string.inline_emoji_search,
+        R.string.inline_emoji_search_summary
+    ) {
+        SwitchPreference(it, Defaults.PREF_INLINE_EMOJI_SEARCH)
     },
     Setting(context, Settings.PREF_ENABLE_CLIPBOARD_HISTORY,
         R.string.enable_clipboard_history, R.string.enable_clipboard_history_summary)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,10 @@
     <string name="vibrate_in_dnd_mode">Vibrate in do not disturb mode</string>
     <!-- Option to play back sound on keypress in soft keyboard -->
     <string name="sound_on_keypress">Sound on keypress</string>
+    <!-- Option to perform inline emoji search -->
+    <string name="inline_emoji_search">Focused emoji suggestions</string>
+    <!-- Description for option to perform inline emoji search -->
+    <string name="inline_emoji_search_summary">Limit suggestions to emojis when a word starts with colon</string>
     <!-- Option to control whether or not to show a popup with a larger font on each key press. -->
     <string name="popup_on_keypress">Popup on keypress</string>
     <!-- Settings screen title for preferences-->


### PR DESCRIPTION
Adding focused emoji suggestions for words starting with `:`. 
`~`s in the search string are converted to spaces during lookup, in order to support multiple-word search strings.
Includes all characters except white space in the emoji search string when initially typed, in order to support search strings with symbols and multiple words. 
However, when restarting a search after moving the cursor etc., only the enclosing word characters are considered, in order to keep it simple. In most cases, the search string will likely be just one word. Is this inconsistency acceptable?
Copied some dictionary support logic from #1542.
Added logic for falling back to a country-less locale when loading a dictionary, which was necessary e.g. for the *Lao (Laos)* language. Should that logic be moved somewhere else?
Made a minor change to `RichInputConnection.isCursorTouchingWord`, so that it doesn't consider emojis as part of a word, in order to support an emoji search right after an existing emoji. This also helps with regular suggestions after an emoji, which are currently missing.
The dictionary library seems to apply sophisticated language analysis, which often results in weird emoji suggestions. Is there any way to use a simpler lookup algorithm?
