### PR TITLE
Fix `locale_key_texts` loading for `he` locale

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/internal/keyboard_parser/LocaleKeyboardInfos.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/keyboard_parser/LocaleKeyboardInfos.kt
@@ -214,7 +214,7 @@ private fun getStreamForLocale(locale: Locale, context: Context) =
         else context.assets.open("$LOCALE_TEXTS_FOLDER/${locale.toLanguageTag()}.txt")
     } catch (_: Exception) {
         try {
-            context.assets.open("$LOCALE_TEXTS_FOLDER/${locale.language}.txt")
+            context.assets.open("$LOCALE_TEXTS_FOLDER/${if (locale.language == "he") "iw" else locale.language}.txt")
         } catch (_: Exception) {
             null
         }


### PR DESCRIPTION
Another `he`/`iw` issue. Hopefully the last one.
