### PR TITLE
Add broadcast intent keys

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/internal/keyboard_parser/floris/KeyCode.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/keyboard_parser/floris/KeyCode.kt
@@ -175,6 +175,10 @@ object KeyCode {
     const val META_LEFT =                 -10048
     const val META_RIGHT =                -10049
 
+    const val SEND_INTENT_ONE =            -10100
+    const val SEND_INTENT_TWO =            -10101
+    const val SEND_INTENT_THREE =          -10102
+
     /** to make sure a FlorisBoard code works when reading a JSON layout */
     fun Int.checkAndConvertCode(): Int = if (this > 0) this else when (this) {
         // working
@@ -190,7 +194,7 @@ object KeyCode {
         ACTION_NEXT, ACTION_PREVIOUS, NOT_SPECIFIED, CLIPBOARD_COPY_ALL, WORD_LEFT, WORD_RIGHT, PAGE_UP,
         PAGE_DOWN, META, TAB, ESCAPE, INSERT, SLEEP, MEDIA_PLAY, MEDIA_PAUSE, MEDIA_PLAY_PAUSE, MEDIA_NEXT,
         MEDIA_PREVIOUS, VOL_UP, VOL_DOWN, MUTE, F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, BACK,
-        TIMESTAMP, CTRL_LEFT, CTRL_RIGHT, ALT_LEFT, ALT_RIGHT, META_LEFT, META_RIGHT
+        TIMESTAMP, CTRL_LEFT, CTRL_RIGHT, ALT_LEFT, ALT_RIGHT, META_LEFT, META_RIGHT, SEND_INTENT_ONE, SEND_INTENT_TWO, SEND_INTENT_THREE,
         -> this
 
         // conversion

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/keyboard_parser/floris/KeyLabel.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/keyboard_parser/floris/KeyLabel.kt
@@ -33,6 +33,10 @@ object KeyLabel {
     const val ESCAPE = "esc"
     const val TIMESTAMP = "timestamp"
 
+    const val SEND_INTENT_ONE = "intent_one"
+    const val SEND_INTENT_TWO = "intent_two"
+    const val SEND_INTENT_THREE = "intent_three"
+
     /** to make sure a FlorisBoard label works when reading a JSON layout */
     // resulting special labels should be names of FunctionalKey enum, case insensitive
     fun String.convertFlorisLabel(): String = when (this) {

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/keyboard_parser/floris/TextKeyData.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/keyboard_parser/floris/TextKeyData.kt
@@ -311,6 +311,9 @@ sealed interface KeyData : AbstractKeyData {
             KeyLabel.CTRL, KeyLabel.ALT, KeyLabel.FN, KeyLabel.META , KeyLabel.ESCAPE -> label.uppercase(Locale.US)
             KeyLabel.TAB -> "!icon/tab_key|!code/${KeyCode.TAB}"
             KeyLabel.TIMESTAMP -> "⌚|!code/${KeyCode.TIMESTAMP}"
+            KeyLabel.SEND_INTENT_ONE -> "<1>|!code/${KeyCode.SEND_INTENT_ONE}"
+            KeyLabel.SEND_INTENT_TWO -> "<2>|!code/${KeyCode.SEND_INTENT_TWO}"
+            KeyLabel.SEND_INTENT_THREE -> "<3>|!code/${KeyCode.SEND_INTENT_THREE}"
             else -> {
                 if (label in toolbarKeyStrings.values) {
                     "!icon/$label|!code/${getCodeForToolbarKey(ToolbarKey.valueOf(label.uppercase(Locale.US)))}"

--- a/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
@@ -6,6 +6,7 @@
 
 package helium314.keyboard.latin.inputlogic;
 
+import android.content.Intent;
 import android.graphics.Color;
 import android.os.SystemClock;
 import android.text.InputType;
@@ -31,6 +32,7 @@ import helium314.keyboard.latin.DictionaryFacilitator;
 import helium314.keyboard.latin.LastComposedWord;
 import helium314.keyboard.latin.LatinIME;
 import helium314.keyboard.latin.NgramContext;
+import helium314.keyboard.latin.R;
 import helium314.keyboard.latin.RichInputConnection;
 import helium314.keyboard.latin.Suggest;
 import helium314.keyboard.latin.Suggest.OnGetSuggestedWordsCallback;
@@ -766,6 +768,9 @@ public final class InputLogic {
             case KeyCode.TIMESTAMP:
                 mLatinIME.onTextInput(TimestampKt.getTimestamp(mLatinIME));
                 break;
+            case KeyCode.SEND_INTENT_ONE, KeyCode.SEND_INTENT_TWO, KeyCode.SEND_INTENT_THREE:
+                handleSendIntentKey(event.getMKeyCode());
+                break;
             case KeyCode.VOICE_INPUT:
                 // switching to shortcut IME, shift state, keyboard,... is handled by LatinIME,
                 // {@link KeyboardSwitcher#onEvent(Event)}, or {@link #onPressKey(int,int,boolean)} and {@link #onReleaseKey(int,boolean)}.
@@ -794,6 +799,15 @@ public final class InputLogic {
         }
     }
 
+    private void handleSendIntentKey(int mKeyCode) {
+        var intentNumber = 1 + (-mKeyCode) - (-KeyCode.SEND_INTENT_ONE);
+
+        Intent intent = new Intent(mLatinIME.getString(R.string.action_send_intent));
+        intent.putExtra(mLatinIME.getString(R.string.extra_number), intentNumber);
+
+        mLatinIME.sendBroadcast(intent);
+        Log.i(TAG, "Sent broadcast for intent number: " + intentNumber);
+    }
     /**
      * Handle an event that is not a functional event.
      * <p>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -897,4 +897,6 @@ New dictionary:
     <string name="custom_subtype">Custom subtype</string>
     <!-- Name for landscape orientation, used in various settings -->
     <string name="landscape">Landscape</string>
+    <string name="action_send_intent">helium314.keyboard.latin.ACTION_SEND_INTENT</string>
+    <string name="extra_number">EXTRA_NUMBER</string>
 </resources>


### PR DESCRIPTION
This commit introduces three new keycodes: SEND_INTENT_ONE, SEND_INTENT_TWO, and SEND_INTENT_THREE.

When these keys are pressed, a broadcast intent is sent with the action `helium314.keyboard.latin.ACTION_SEND_INTENT`. The intent includes an extra `EXTRA_NUMBER` (integer) indicating which of the three keys was pressed (1, 2, or 3).

This functionality allows external applications to react to these specific key presses.
