### PR TITLE
Fix `onInlineSuggestionsResponse` crash

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/LatinIME.java
+++ b/app/src/main/java/helium314/keyboard/latin/LatinIME.java
@@ -1386,6 +1386,10 @@ public class LatinIME extends InputMethodService implements
     @RequiresApi(api = Build.VERSION_CODES.R)
     public boolean onInlineSuggestionsResponse(InlineSuggestionsResponse response) {
         Log.d(TAG,"onInlineSuggestionsResponse called");
+        if (Settings.getValues().mSuggestionStripHiddenPerUserSettings) {
+            return false;
+        }
+
         final List<InlineSuggestion> inlineSuggestions = response.getInlineSuggestions();
         if (inlineSuggestions.isEmpty()) {
             return false;


### PR DESCRIPTION
Turns out `onInlineSuggestionsResponse` gets called several times after one `onCreateInlineSuggestionsRequest` call, and if you hide the toolbar in the meantime, you get a crash.

