### PR TITLE
Make `debugNoMinify` the default `buildType`

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,6 +51,7 @@ android {
             isJniDebuggable = false
             signingConfig = signingConfigs.getByName("debug")
             applicationIdSuffix = ".debug"
+            isDefault = true
         }
         base.archivesBaseName = "HeliBoard_" + defaultConfig.versionName
     }


### PR DESCRIPTION
To avoid having to select it on every Android Studio load.
Hopefully this doesn't interfere with the automated builds.
