### PR TITLE
Auto-capitalize current word when pressing Shift

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
@@ -1574,7 +1574,8 @@ public final class InputLogic {
 
         var script = KeyboardSwitcher.getInstance().getCurrentKeyboardScript();
         var wordAtCursor = mConnection.getWordRangeAtCursor(settingsValues.mSpacingAndPunctuations, script);
-        if (wordAtCursor != null && wordAtCursor.length() > 0) {
+        if (wordAtCursor != null && wordAtCursor.length() > 0 && ! (settingsValues.mUrlDetectionEnabled
+                    && settingsValues.mSpacingAndPunctuations.containsSometimesWordConnector(wordAtCursor.mWord))) {
             var cursorPosition = mConnection.getExpectedSelectionStart();
             var wordStart = cursorPosition - wordAtCursor.getNumberOfCharsInWordBeforeCursor();
             var wordEnd = cursorPosition + wordAtCursor.getNumberOfCharsInWordAfterCursor();


### PR DESCRIPTION
When pressing *Shift* with no selection and the cursor touching a word, that word will be auto-capitalized the same way a selection is today.

The downside is [this](https://github.com/Helium314/HeliBoard/issues/783#issuecomment-2238231874) - there's no good way to type a capital letter in the middle of a word, and the case of the next letter you type is tied to the capitalization mode you selected.

The test that failed demonstrated some fragility too.

[This](https://github.com/Helium314/HeliBoard/issues/783#issuecomment-2667873696) may be a better solution.

This feature should probably be enabled through a setting.

Fixes #540, fixes #783.
