### PR TITLE
Dismiss more suggestions on touch outside the keyboard

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/InputView.java
+++ b/app/src/main/java/helium314/keyboard/latin/InputView.java
@@ -235,10 +235,10 @@ public final class InputView extends FrameLayout {
      * outside of it.
      */
     private static class MoreSuggestionsViewCanceler
-            extends MotionEventForwarder<MainKeyboardView, SuggestionStripView> {
+            extends MotionEventForwarder<View, SuggestionStripView> {
         public MoreSuggestionsViewCanceler(final MainKeyboardView mainKeyboardView,
                 final SuggestionStripView suggestionStripView) {
-            super(mainKeyboardView, suggestionStripView);
+            super(mainKeyboardView.getRootView(), suggestionStripView);
         }
 
         @Override


### PR DESCRIPTION
Currently, when more suggestions are in modal mode, the only way to dismiss them is by touching the keyboard, which is counterintuitive - you usually avoid touching buttons when you just want to dismiss a popup.

This change makes it so touching anywhere outside the suggestions will dismiss them.
