### PR TITLE
Fix detection of keys on wide shifted popups

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/PopupKeysKeyboard.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PopupKeysKeyboard.java
@@ -304,7 +304,7 @@ public final class PopupKeysKeyboard extends Keyboard {
                     ? defaultColumns
                     : (spaceForKeys > 0 ? spaceForKeys : defaultColumns); // in last case setParameters will throw an exception
             mParams.setParameters(popupKeys.length, finalNumColumns, keyWidth,
-                    rowHeight, key.getX() + keyWidth / 2, keyboard.mId.mWidth,
+                    rowHeight, key.getX() + key.getWidth() / 2, keyboard.mId.mWidth,
                     key.isPopupKeysFixedColumn(), key.isPopupKeysFixedOrder(), dividerWidth);
         }
 


### PR DESCRIPTION
Adjust `mOriginX` when a popup is shifted because it's too wide for its intended position.

Fixes #1786.
