### PR TITLE
Disable "Always use middle suggestion" when suggestions are resumed

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/Suggest.kt
+++ b/app/src/main/java/helium314/keyboard/latin/Suggest.kt
@@ -119,7 +119,7 @@ class Suggest(private val mDictionaryFacilitator: DictionaryFacilitator) {
         // If there is an incoming autocorrection, make sure typed word is shown, so user is able to override it.
         // Otherwise, if the relevant setting is enabled, show the typed word in the middle.
         val indexOfTypedWord = if (hasAutoCorrection) 2 else 1
-        if ((hasAutoCorrection || Settings.getValues().mCenterSuggestionTextToEnter)
+        if ((hasAutoCorrection || Settings.getValues().mCenterSuggestionTextToEnter && !wordComposer.isResumed)
             && suggestionsList.size >= indexOfTypedWord && !TextUtils.isEmpty(typedWordString)) {
             if (typedWordFirstOccurrenceWordInfo != null) {
                 if (SuggestionStripView.DEBUG_SUGGESTIONS) addDebugInfo(typedWordFirstOccurrenceWordInfo, typedWordString)


### PR DESCRIPTION
When the cursor is moved to the middle of an existing word, autocorrect is effectively off, so showing the current word as the middle suggestion doesn't make sense I think. See discussion on #1774.
