### PR TITLE
Fix switching back to previous locale after switching based on `hintLocales`

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/LatinIME.java
+++ b/app/src/main/java/helium314/keyboard/latin/LatinIME.java
@@ -915,6 +915,10 @@ public class LatinIME extends InputMethodService implements
             return;
         }
         InputMethodSubtype oldSubtype = mRichImm.getCurrentSubtype().getRawSubtype();
+        if (subtype.equals(oldSubtype)) {
+            // onStartInput may be called more than once, resulting in duplicate subtype switches
+            return;
+        }
 
         mSubtypeState.onSubtypeChanged(oldSubtype, subtype);
         StatsUtils.onSubtypeChanged(oldSubtype, subtype);


### PR DESCRIPTION
Turns out there are multiple instances of the same `InputMethodSubtype`, which caused this condition to incorrectly hold true.

Possibly related to https://github.com/Helium314/HeliBoard/issues/596#issuecomment-2859846750.
