### PR TITLE
fix: fix license link in 'About' screen

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/common/Constants.kt
+++ b/app/src/main/java/helium314/keyboard/latin/common/Constants.kt
@@ -7,7 +7,7 @@ object Links {
     const val DICTIONARY_NORMAL_SUFFIX = "dictionaries/"
     const val DICTIONARY_EXPERIMENTAL_SUFFIX = "dictionaries_experimental/"
     const val GITHUB = "https://github.com/Helium314/HeliBoard"
-    const val LICENSE = "$GITHUB/blob/main/LICENSE-GPL-3"
+    const val LICENSE = "$GITHUB/blob/main/LICENSE"
     const val LAYOUT_FORMAT_URL = "$GITHUB/blob/main/layouts.md"
     const val CUSTOM_LAYOUTS = "$GITHUB/discussions/categories/custom-layout"
     const val CUSTOM_COLORS = "$GITHUB/discussions/categories/custom-colors"


### PR DESCRIPTION
missed while refactoring to compose.