### PR TITLE
Add Portuguese Hcesar layout

### DIFF
--- a/app/src/main/assets/layouts/main/hcesar.json
+++ b/app/src/main/assets/layouts/main/hcesar.json
@@ -1,0 +1,45 @@
+[
+  [
+    { "label": "h" },
+    { "label": "c" },
+    { "label": "e" },
+    { "label": "s" },
+    { "label": "a" },
+    { "label": "r" },
+    { "label": "o" },
+    { "label": "p" },
+    { "label": "z" },
+    { "$": "shift_state_selector",
+      "shifted": { "label": "«" },
+      "default": { "label": "," }
+}
+  ],
+  [
+    { "label": "q" },
+    { "label": "t" },
+    { "label": "d" },
+    { "label": "i" },
+    { "label": "n" },
+    { "label": "u" },
+    { "label": "l" },
+    { "label": "m" },
+    { "label": "x" },
+    { "$": "shift_state_selector",
+      "shifted": { "label": "»" },
+      "default": { "label": "." }
+}
+  ],
+  [
+    { "label": "ç" },
+    { "label": "j" },
+    { "label": "b" },
+    { "label": "f" },
+    { "label": "v" },
+    { "label": "g" },
+    { "label": "k" }
+  ],
+  [
+    { "label": "y" },
+    { "label": "w" }
+  ]
+]

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -398,6 +398,8 @@
     <!-- Description for Spanish (US) keyboard subtype
          (US) should be an abbreviation of United States. -->
     <string name="subtype_es_US">Spanish (US)</string>
+    <!-- Description for Portuguese (HCESAR) keyboard subtype -->
+    <string name="subtype_hc">Portuguese (HCESAR)</string>
     <!-- Description for Serbian (Latin) keyboard subtype -->
     <string name="subtype_sr_Latn">Serbian (Latin)</string>
     <!-- Description for Hinglish (https://en.wikipedia.org/wiki/Hinglish) keyboard subtype -->

--- a/app/src/main/res/xml/method.xml
+++ b/app/src/main/res/xml/method.xml
@@ -100,6 +100,7 @@
     pms: Piedmontese/qwerty
     pt_BR: Portuguese (Brazil)/qwerty
     pt_PT: Portuguese (Portugal)/qwerty
+    pt_PT: Portuguese (HCESAR)/hcesar	
     ro: Romanian/qwerty
     ru: Russian/russian
     ru: Russian (Extended)/russian_extended
@@ -1027,6 +1028,15 @@
         android:imeSubtypeExtraValue="AsciiCapable,EmojiCapable"
         android:isAsciiCapable="true"
     />
+	   <subtype android:icon="@drawable/ic_ime_switcher"  
+        android:label="@string/subtype_hc" 
+        android:subtypeId="0x1a2b3c42"
+        android:imeSubtypeLocale="pt_PT"
+        android:languageTag="pt-PT"
+        android:imeSubtypeMode="keyboard"
+        android:imeSubtypeExtraValue="KeyboardLayoutSet=MAIN:hcesar,AsciiCapable,EmojiCapable"
+        android:isAsciiCapable="true"
+    />	
     <subtype android:icon="@drawable/ic_ime_switcher"
         android:label="@string/subtype_generic"
         android:subtypeId="0x8d185978"


### PR DESCRIPTION

<img width="234" height="416" alt="Screenshot_20250821_002548_1_optimized" src="https://github.com/user-attachments/assets/c6ae3c9c-1207-400e-95d9-295629f94595" />

Hcesar layout ready for portuguese language.
Thank you.
