### PR TITLE
Add plural schwa ɜ in Italian keyboard

### DIFF
--- a/app/src/main/assets/locale_key_texts/it.txt
+++ b/app/src/main/assets/locale_key_texts/it.txt
@@ -1,6 +1,6 @@
 [popup_keys]
 a à ª
-e è é ə
+e è é ə ɜ
 i ì
 o ò ó º
 u ù


### PR DESCRIPTION
This pull request adds the plural schwa letter (`ɜ`) to the Italian keyboard layout, in the popup for the `e` key. The `e` key has been chosen to mimic the implementation of the Apple default iOS keyboard.

This change expands on https://github.com/Helium314/HeliBoard/pull/1275.