### PR TITLE
Add Portuguese Nativo layout

### DIFF
--- a/app/src/main/assets/layouts/main/nativo.json
+++ b/app/src/main/assets/layouts/main/nativo.json
@@ -1,0 +1,56 @@
+[
+  [
+    { "$": "shift_state_selector",
+      "shifted": { "label": "?" },
+      "default": { "$": "variation_selector",
+        "uri": { "label": "/" },
+        "email": { "label": "@" },
+        "default": { "label": "'", "popup": { "relevant": [
+          { "label": "!" },
+          { "label": "\"" }
+        ] } }
+      }
+    },
+    { "$": "shift_state_selector",
+      "shifted": { "label": "<" },
+      "default": { "label": "," }
+    },
+    { "$": "shift_state_selector",
+      "shifted": { "label": ">" },
+      "default": { "label": "." }
+    },
+    { "label": "h" },
+    { "label": "x" },
+    { "label": "w" },
+    { "label": "l" },
+    { "label": "t" },
+    { "label": "c" },
+    { "label": "p" }
+  ],
+  [
+    { "label": "i" },
+    { "label": "e" },
+    { "label": "a" },
+    { "label": "o" },
+    { "label": "u" },
+    { "label": "m" },
+    { "label": "d" },
+    { "label": "s" },
+    { "label": "r" },
+    { "label": "n" }
+  ],
+  [
+    { "label": "ç" },
+    { "label": "j" },
+    { "label": "b" },
+    { "label": "k" },
+    { "label": "q" },
+    { "label": "v" },
+    { "label": "g" },
+	{ "label": "f" }
+  ],
+  [
+    { "label": "y" },
+    { "label": "z" }
+  ]
+]

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -399,6 +399,8 @@
          (US) should be an abbreviation of United States. -->
     <string name="subtype_es_US">Spanish (US)</string>
     <!-- Description for Serbian (Latin) keyboard subtype -->
+    <!-- Description for Portuguese (Nativo) keyboard subtype -->
+    <string name="subtype_pt_NT">Portuguese (Nativo)</string>
     <string name="subtype_sr_Latn">Serbian (Latin)</string>
     <!-- Description for Hinglish (https://en.wikipedia.org/wiki/Hinglish) keyboard subtype -->
     <string name="subtype_hi_Latn">Hinglish</string>

--- a/app/src/main/res/xml/method.xml
+++ b/app/src/main/res/xml/method.xml
@@ -100,6 +100,7 @@
     pms: Piedmontese/qwerty
     pt_BR: Portuguese (Brazil)/qwerty
     pt_PT: Portuguese (Portugal)/qwerty
+    pt_BR: Portuguese (Nativo)/nativo	
     ro: Romanian/qwerty
     ru: Russian/russian
     ru: Russian (Extended)/russian_extended
@@ -1027,6 +1028,15 @@
         android:imeSubtypeExtraValue="AsciiCapable,EmojiCapable"
         android:isAsciiCapable="true"
     />
+    <subtype android:icon="@drawable/ic_ime_switcher"  
+        android:label="@string/subtype_pt_NT" 
+        android:subtypeId="0x4f5e6d7a"
+        android:imeSubtypeLocale="pt_BR"
+        android:languageTag="pt-BR"
+        android:imeSubtypeMode="keyboard"
+        android:imeSubtypeExtraValue="KeyboardLayoutSet=MAIN:nativo,AsciiCapable,EmojiCapable"
+        android:isAsciiCapable="true"
+    />	
     <subtype android:icon="@drawable/ic_ime_switcher"
         android:label="@string/subtype_generic"
         android:subtypeId="0x8d185978"


### PR DESCRIPTION

<img width="234" height="416" alt="Screenshot_20250823_173014 (2)" src="https://github.com/user-attachments/assets/e8ee1a2c-e49b-4500-84df-cc6827f6e1f7" />

I'm adding a Portuguese version of the "Nativo" layout for the Portuguese language. 
Portuguese Nativo is a layout optimized for Portuguese and its also called br-nativo. 

The version used on Linux is here: 
https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/blob/master/symbols/pt
The only difference from the Brazilian one (ABNT2), is that the /? key is '?

More information: 
https://support.getfreewrite.com/article/27-freewrite-keyboard-layouts
http://www.xahlee.info/kbd/pt-nativo_keyboard_layout.html
https://github.com/openboard-team/openboard/pull/864

