### PR TITLE
Add Mirandese language 

### DIFF
--- a/app/src/main/assets/locale_key_texts/mwl.txt
+++ b/app/src/main/assets/locale_key_texts/mwl.txt
@@ -1,6 +1,6 @@
 [popup_keys]
 a á ª
-e é 
+e é
 i í
 o ó º
 u ú ũ

--- a/app/src/main/res/xml/method.xml
+++ b/app/src/main/res/xml/method.xml
@@ -91,7 +91,7 @@
     mn_MN: Mongolian (Mongolia)/mongolian
     mr_IN: Marathi (India)/marathi
     ms_MY: Malay (Malaysia)/qwerty
-    mwl: Mirandese/qwerty	
+    mwl: Mirandese/qwerty
     nb: Norwegian Bokmål/qwerty+
     ne_NP: Nepali (Nepal) Romanized/nepali_romanized
     ne_NP: Nepali (Nepal) Traditional/nepali_traditional
@@ -955,7 +955,7 @@
         android:imeSubtypeMode="keyboard"
         android:imeSubtypeExtraValue="AsciiCapable,EmojiCapable"
         android:isAsciiCapable="true"
-    />		
+    />
     <subtype android:icon="@drawable/ic_ime_switcher"
         android:label="@string/subtype_generic"
         android:subtypeId="0x3f12ee14"


### PR DESCRIPTION
I would like to propose the addition of support for the Mirandese language in the Heliboard app. 
Mirandese is an Asturian-Leonese language spoken in Portugal, with approximately 3,500 speakers.

<img width="180" height="320" alt="mirandese (2)" src="https://github.com/user-attachments/assets/f3f3c8c0-79e4-44e3-b071-fb7ed7e5e3cb" />

For a dictionary, the best one was made by Amadeu Ferreira with 12.000 words.
This worldlist with 4.700 words was generated from [wikitionary](https://pt.wiktionary.org/wiki/Categoria:!Entrada_(Mirand%C3%AAs)): 
[mirandes_wordlist.txt](https://github.com/user-attachments/files/21957324/mirandes_wordlist.txt)
