### PR TITLE
Fix adding quotes to suggestions when word contains quotes

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/Suggest.kt
+++ b/app/src/main/java/helium314/keyboard/latin/Suggest.kt
@@ -486,7 +486,8 @@ class Suggest(private val mDictionaryFacilitator: DictionaryFacilitator) {
                     || -1 == info.mWord.indexOf(Constants.CODE_SPACE.toChar()))
         }
 
-        private fun getTransformedSuggestedWordInfo(
+        // public for testing
+        fun getTransformedSuggestedWordInfo(
             wordInfo: SuggestedWordInfo, locale: Locale, isAllUpperCase: Boolean,
             isOnlyFirstCharCapitalized: Boolean, trailingSingleQuotesCount: Int
         ): SuggestedWordInfo {
@@ -497,7 +498,7 @@ class Suggest(private val mDictionaryFacilitator: DictionaryFacilitator) {
             val quotesToAppend = (trailingSingleQuotesCount
                     - if (-1 == wordInfo.mWord.indexOf(Constants.CODE_SINGLE_QUOTE.toChar())) 0 else 1)
             for (i in quotesToAppend - 1 downTo 0) {
-                capitalizedWord = capitalizedWord + Constants.CODE_SINGLE_QUOTE
+                capitalizedWord = "$capitalizedWord'"
             }
             return SuggestedWordInfo(
                 capitalizedWord, wordInfo.mPrevWordsContext,

--- a/app/src/test/java/helium314/keyboard/latin/SuggestTest.kt
+++ b/app/src/test/java/helium314/keyboard/latin/SuggestTest.kt
@@ -26,6 +26,7 @@ import org.robolectric.shadows.ShadowLog
 import java.util.*
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 @Suppress("NonAsciiCharacters")
 @RunWith(RobolectricTestRunner::class)
@@ -266,6 +267,12 @@ class SuggestTest {
             thresholdAggressive
         )
         assert(!result.last()) // should not be corrected
+    }
+
+    @Test fun `quotes are added to suggestions when needed`() {
+        val result = Suggest.Companion.getTransformedSuggestedWordInfo(suggestion("word", 1, Locale.ENGLISH, true),
+            Locale.ENGLISH, false, false, 1)
+        assertEquals("word'", result.mWord)
     }
 
     private fun shouldBeAutoCorrected(word: String, // typed word


### PR DESCRIPTION
This bug was introduced in #1807.

Added test.

Fixes #1905.
