### PR TITLE
Fix for white text bug in Description of hidden features

### DIFF
--- a/app/src/main/java/helium314/keyboard/settings/screens/AboutScreen.kt
+++ b/app/src/main/java/helium314/keyboard/settings/screens/AboutScreen.kt
@@ -6,8 +6,6 @@ import android.app.AlertDialog
 import android.content.Context
 import android.content.Intent
 import android.text.method.LinkMovementMethod
-import android.text.Html
-import android.text.Spanned
 import android.view.View
 import android.widget.TextView
 import android.widget.Toast
@@ -118,13 +116,7 @@ fun createAboutSettings(context: Context) = listOf(
                 val link = ("<a href=\"https://developer.android.com/reference/android/content/Context#createDeviceProtectedStorageContext()\">"
                         + ctx.getString(R.string.hidden_features_text) + "</a>")
                 val message = ctx.getString(R.string.hidden_features_message, link)
-val htmlString = message 
-val dialogMessage: Spanned = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
-    Html.fromHtml(htmlString, Html.FROM_HTML_MODE_LEGACY)
-} else {
-    @Suppress("DEPRECATION")
-    Html.fromHtml(htmlString)
-}
+                val dialogMessage = SpannableStringUtils.fromHtml(message)
                 val builder = AlertDialog.Builder(ctx)
                     .setIcon(R.drawable.ic_settings_about_hidden_features)
                     .setTitle(R.string.hidden_features_title)
@@ -132,11 +124,6 @@ val dialogMessage: Spanned = if (android.os.Build.VERSION.SDK_INT >= android.os.
                     .setPositiveButton(R.string.dialog_close, null)
                     .create()
                 builder.show()
-                val messageView = builder.findViewById<TextView>(android.R.id.message)
-                if (messageView != null) {
-                    messageView.movementMethod = LinkMovementMethod.getInstance() 
-                    messageView.setTextColor(android.graphics.Color.BLACK)    
-                }							
                 (builder.findViewById<View>(android.R.id.message) as TextView).movementMethod = LinkMovementMethod.getInstance()
             },
             icon = R.drawable.ic_settings_about_hidden_features

--- a/app/src/main/res/values/platform-theme.xml
+++ b/app/src/main/res/values/platform-theme.xml
@@ -20,6 +20,7 @@
         <item name="android:colorAccent">@color/accent</item>
         <item name="android:background">@color/action_bar_color</item>
         <item name="android:textColor">@color/foreground</item>
+        <item name="android:textColorPrimary">@color/foreground</item>
         <item name="android:textColorAlertDialogListItem">@color/foreground</item>
         <item name="android:colorForeground">@color/foreground</item>
     </style>


### PR DESCRIPTION
The Description of hidden features was white, (OnePlus 5)
This bug was introduced in [HeliBoard 3.0-alpha2](https://github.com/Helium314/HeliBoard/releases/tag/v3.0-alpha2)

Fixes https://github.com/Helium314/HeliBoard/issues/1657