### PR TITLE
Disable default long-press haptic for clipboard entries

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardAdapter.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardAdapter.kt
@@ -58,6 +58,7 @@ class ClipboardAdapter(
                 setOnTouchListener(this@ViewHolder)
                 setOnLongClickListener(this@ViewHolder)
                 setBackgroundResource(itemBackgroundId)
+                isHapticFeedbackEnabled = false
             }
             Settings.getValues().mColors.setBackground(view, ColorType.KEY_BACKGROUND)
             pinnedIconView = view.findViewById<ImageView>(R.id.clipboard_entry_pinned_icon).apply {


### PR DESCRIPTION
Fixes #2026

Disables default long-press haptic on clipboard entries so vibration respects app settings and custom duration...

- In `ClipboardAdapter.kt`, sets `isHapticFeedbackEnabled = false` on the entry view to prevent Android's default long-press haptic. Haptics still occur on touch-down via the existing `onPressKey` path (`AudioAndHapticFeedbackManager`) (which honors settings).

Testing:
- Turn off key press vibration: no vibration on long-press.
- Set custom vibration duration: touch-down haptic matches duration on clipboard tap.

Naturally it also follows the DND vibration setting.