### PR TITLE
Add haptic feedback for clipboard toolbar keys

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardHistoryView.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardHistoryView.kt
@@ -22,6 +22,7 @@ import helium314.keyboard.keyboard.PointerTracker
 import helium314.keyboard.keyboard.internal.KeyDrawParams
 import helium314.keyboard.keyboard.internal.KeyVisualAttributes
 import helium314.keyboard.keyboard.internal.keyboard_parser.floris.KeyCode
+import helium314.keyboard.latin.AudioAndHapticFeedbackManager
 import helium314.keyboard.latin.ClipboardHistoryManager
 import helium314.keyboard.latin.R
 import helium314.keyboard.latin.common.ColorType
@@ -196,6 +197,7 @@ class ClipboardHistoryView @JvmOverloads constructor(
     override fun onClick(view: View) {
         val tag = view.tag
         if (tag is ToolbarKey) {
+            AudioAndHapticFeedbackManager.getInstance().performHapticAndAudioFeedback(KeyCode.NOT_SPECIFIED, this)
             val code = getCodeForToolbarKey(tag)
             if (code != KeyCode.UNSPECIFIED) {
                 keyboardActionListener.onCodeInput(code, Constants.NOT_A_COORDINATE, Constants.NOT_A_COORDINATE, false)
@@ -207,6 +209,7 @@ class ClipboardHistoryView @JvmOverloads constructor(
     override fun onLongClick(view: View): Boolean {
         val tag = view.tag
         if (tag is ToolbarKey) {
+            AudioAndHapticFeedbackManager.getInstance().performHapticAndAudioFeedback(Constants.NOT_A_CODE, this)
             val longClickCode = getCodeForToolbarKeyLongClick(tag)
             if (longClickCode != KeyCode.UNSPECIFIED) {
                 keyboardActionListener.onCodeInput(


### PR DESCRIPTION
Fixes #2024

Make clipboard toolbar keys vibrate like regular toolbar keys when "Vibrate on key press" is enabled...

- In `ClipboardHistoryView.kt`, routes `onClick`/`onLongClick` through `AudioAndHapticFeedbackManager` (import added + two calls), matching `SuggestionStripView` behavior

Testing:

- Enable "Vibrate on key press"
- Open clipboard keyboard > press toolbar buttons > haptic occurs.
- Disable vibration > no haptic