### PR TITLE
Fix `TextInputDialog` focus on launch

### DIFF
--- a/app/src/main/java/helium314/keyboard/settings/dialogs/TextInputDialog.kt
+++ b/app/src/main/java/helium314/keyboard/settings/dialogs/TextInputDialog.kt
@@ -44,17 +44,6 @@ fun TextInputDialog(
     reducePadding: Boolean = false,
     checkTextValid: (text: String) -> Boolean = { it.isNotBlank() }
 ) {
-    val focusRequester = remember { FocusRequester() }
-    // crappy workaround because otherwise we get a disappearing dialog and a crash
-    // but doesn't work perfectly, dialog doesn't nicely show up again...
-    // todo: understand why it works in ExpandableSearchField, but not here
-    var done by rememberSaveable { mutableStateOf(false) }
-    LaunchedEffect(initialText) {
-        if (done) return@LaunchedEffect
-        focusRequester.requestFocus()
-        done = true
-    }
-
     var value by rememberSaveable(stateSaver = TextFieldValue.Saver) {
         mutableStateOf(TextFieldValue(initialText, selection = TextRange(if (singleLine) initialText.length else 0)))
     }
@@ -69,6 +58,7 @@ fun TextInputDialog(
         modifier = modifier,
         title = title,
         content = {
+            val focusRequester = remember { FocusRequester() }
             OutlinedTextField(
                 value = value,
                 onValueChange = { value = it },
@@ -80,6 +70,7 @@ fun TextInputDialog(
                 singleLine = singleLine,
                 textStyle = contentTextDirectionStyle,
             )
+            LaunchedEffect(Unit) { focusRequester.requestFocus() }
         },
         properties = properties,
         reducePadding = reducePadding,


### PR DESCRIPTION
It appears that with the Compose upgrade from `compose-bom:2025.05.00` to `compose-bom:2025.08.00`, `TextInputDialog` lost its focus-on-launch behavior. As a result, the layout editor takes most of the screen height on launch, and when the keyboard opens, it shrinks, potentially hiding the cursor, since Compose doesn't automatically keep the cursor in view on resize.

This PR fixes the focus on launch behavior. You can still get the hiding cursor issue if you hide and re-show the keyboard. Fixing that requires a much more involved change.

Fixes #2039.
