### PR TITLE
Default new dictionary locale to best-matching enabled subtype locale

### DIFF
--- a/app/src/main/java/helium314/keyboard/settings/dialogs/NewDictionaryDialog.kt
+++ b/app/src/main/java/helium314/keyboard/settings/dialogs/NewDictionaryDialog.kt
@@ -49,15 +49,23 @@ fun NewDictionaryDialog(
     } else if (header != null) {
         val ctx = LocalContext.current
         val dictLocale = header.mLocaleString.constructLocale()
-        val enabledLanguages = SubtypeSettings.getEnabledSubtypes().map { it.locale() }
-        val comparer = compareBy<Locale>({ it != mainLocale }, { it !in enabledLanguages },
-            { it != dictLocale }, { it.language !in enabledLanguages.map { it.language } }, { it.script() != dictLocale.script() })
+        val enabledLocales = SubtypeSettings.getEnabledSubtypes().map { it.locale() }
+        val enabledLanguages = enabledLocales.map { it.language }
+        val comparer = compareBy<Locale>(
+            { it != mainLocale },
+            { it !in enabledLocales },
+            { it != dictLocale },
+            { it.language !in enabledLanguages },
+            { it.script() != dictLocale.script() }
+        )
         val locales = SubtypeSettings.getAvailableSubtypeLocales()
             .filter { it.script() == dictLocale.script() || it.script() == mainLocale?.script() }
             .sortedWith(comparer)
         var locale by remember {
-            mutableStateOf(mainLocale ?: RichInputMethodManager.getInstance().findSubtypeForHintLocale(dictLocale)?.locale()
-            ?: dictLocale.takeIf { it in locales } ?: locales.first())
+            mutableStateOf(mainLocale
+                ?: RichInputMethodManager.getInstance().findSubtypeForHintLocale(dictLocale)?.locale()
+                ?: dictLocale.takeIf { it in locales }
+                ?: locales.first())
         }
         val cacheDir = DictionaryInfoUtils.getCacheDirectoryForLocale(locale, ctx)
         val dictFile = File(cacheDir, header.mIdString.substringBefore(":") + "_" + DictionaryInfoUtils.USER_DICTIONARY_SUFFIX)


### PR DESCRIPTION
Also, put enabled subtype locales at the top of the list.

Addresses https://github.com/Helium314/HeliBoard/issues/1718#issuecomment-3470711547.
