### PR TITLE
Cancel inline emoji search in `startInput`

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
@@ -166,6 +166,7 @@ public final class InputLogic {
         cancelDoubleSpacePeriodCountdown();
         mInputLogicHandler.reset();
         mConnection.requestCursorUpdates(true, true);
+        setInlineEmojiSearchAction(false);
     }
 
     /**
@@ -2659,7 +2660,12 @@ public final class InputLogic {
 
     private void deleteTextReplacedByEmoji() {
         mConnection.finishComposingText();
-        mConnection.deleteTextBeforeCursor(getInlineEmojiSearchString().length() + 1);
+        var inlineEmojiSearchString = getInlineEmojiSearchString();
+        if (inlineEmojiSearchString != null) {
+            mConnection.deleteTextBeforeCursor(inlineEmojiSearchString.length() + 1);
+        } else {
+            Log.e("inlineEmojiSearch", "Inconsistent state - inlineEmojiSearchString is null");
+        }
     }
 
     private String getInlineEmojiSearchString() {


### PR DESCRIPTION
Also add defensive null check in case we get out of sync.

Addresses https://github.com/Helium314/HeliBoard/issues/259#issuecomment-3555217702.
