### PR TITLE
Don't enter inline emoji search if string contains a newline

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
@@ -2676,7 +2676,15 @@ public final class InputLogic {
         return getInlineEmojiSearchString(mConnection.getTextBeforeCursor(50, 0));
     }
 
-    // public for testing
+    /**
+     * Gets the inline emoji search string. Rules:
+     * - string starts with last colon before the cursor
+     * - the character before the colon has to be non-word, non-digit
+     * - the character after the colon has to be non-space
+     * - the string cannot contain newlines
+     * <p>
+     * Public for testing.
+     */
     public static String getInlineEmojiSearchString(CharSequence textBeforeCursor) {
         if (textBeforeCursor == null) {
             return null;
@@ -2693,6 +2701,10 @@ public final class InputLogic {
         }
 
         if (Character.isWhitespace(text.codePointAt(markerIndex + 1))) {
+            return null;
+        }
+
+        if (text.indexOf('\n', markerIndex + 2) >= 0) {
             return null;
         }
 

--- a/app/src/test/java/helium314/keyboard/latin/InputLogicTest.kt
+++ b/app/src/test/java/helium314/keyboard/latin/InputLogicTest.kt
@@ -715,6 +715,7 @@ class InputLogicTest {
         assertEquals(null, InputLogic.getInlineEmojiSearchString("6:test"))
         assertEquals("test", InputLogic.getInlineEmojiSearchString("🌍:test"))
         assertEquals("test", InputLogic.getInlineEmojiSearchString(",:test"))
+        assertEquals(null, InputLogic.getInlineEmojiSearchString(":test\nt"))
     }
 
     // ------- helper functions ---------


### PR DESCRIPTION
When you type an inline emoji search, you cannot enter a newline, so it makes sense to not start a search when the string contains one.

Addresses https://github.com/Helium314/HeliBoard/issues/259#issuecomment-3555629990.
