### PR TITLE
Fix for external keyboard

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListener.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListener.java
@@ -13,29 +13,26 @@ import helium314.keyboard.latin.common.Constants;
 import helium314.keyboard.latin.common.InputPointers;
 
 public interface KeyboardActionListener {
+
+    enum Direction {
+        UP, DOWN, LEFT, RIGHT
+    }
+
     /**
      * Called when the user presses a key. This is sent before the {@link #onCodeInput} is called.
      * For keys that repeat, this is only called once.
-     *
-     * @param primaryCode the unicode of the key being pressed. If the touch is not on a valid key,
-     *            the value will be zero.
-     * @param repeatCount how many times the key was repeated. Zero if it is the first press.
-     * @param isSinglePointer true if pressing has occurred while no other key is being pressed.
-     * @param hapticEvent the type of haptic feedback to perform.
      */
     void onPressKey(int primaryCode, int repeatCount, boolean isSinglePointer, HapticEvent hapticEvent);
 
     void onLongPressKey(int primaryCode);
 
     /**
-     * Called when the user releases a key. This is sent after the {@link #onCodeInput} is called.
-     * For keys that repeat, this is only called once.
-     *
-     * @param primaryCode the code of the key that was released
-     * @param withSliding true if releasing has occurred because the user slid finger from the key
-     *             to other key without releasing the finger.
+     * Called when the user releases a key.
      */
     void onReleaseKey(int primaryCode, boolean withSliding);
+
+    void onMoveFocus(Direction direction);
+    void onPressFocusedKey();
 
     /** For handling hardware key presses. Returns whether the event was handled. */
     boolean onKeyDown(int keyCode, KeyEvent keyEvent);
@@ -45,68 +42,33 @@ public interface KeyboardActionListener {
 
     /**
      * Send a key code to the listener.
-     *
-     * @param primaryCode this is the code of the key that was pressed
-     * @param x x-coordinate pixel of touched event. If onCodeInput is not called by
-     *            {@link PointerTracker} or so, the value should be
-     *            {@link Constants#NOT_A_COORDINATE}. If it's called on insertion from the
-     *            suggestion strip, it should be {@link Constants#SUGGESTION_STRIP_COORDINATE}.
-     * @param y y-coordinate pixel of touched event. If #onCodeInput is not called by
-     *            {@link PointerTracker} or so, the value should be
-     *            {@link Constants#NOT_A_COORDINATE}.If it's called on insertion from the
-     *            suggestion strip, it should be {@link Constants#SUGGESTION_STRIP_COORDINATE}.
-     * @param isKeyRepeat true if this is a key repeat, false otherwise
      */
-    // TODO: change this to send an Event object instead
     void onCodeInput(int primaryCode, int x, int y, boolean isKeyRepeat);
 
-    /**
-     * Sends a string of characters to the listener.
-     *
-     * @param text the string of characters to be registered.
-     */
+    /** Sends a string of characters to the listener. */
     void onTextInput(String text);
 
-    /**
-     * Called when user started batch input.
-     */
+    /** Called when user started batch input. */
     void onStartBatchInput();
 
-    /**
-     * Sends the ongoing batch input points data.
-     * @param batchPointers the batch input points representing the user input
-     */
+    /** Sends the ongoing batch input points data. */
     void onUpdateBatchInput(InputPointers batchPointers);
 
-    /**
-     * Sends the final batch input points data.
-     *
-     * @param batchPointers the batch input points representing the user input
-     */
+    /** Sends the final batch input points data. */
     void onEndBatchInput(InputPointers batchPointers);
 
     void onCancelBatchInput();
 
-    /**
-     * Called when user released a finger outside any key.
-     */
+    /** Called when user released a finger outside any key. */
     void onCancelInput();
 
-    /**
-     * Called when user finished sliding key input.
-     */
+    /** Called when user finished sliding key input. */
     void onFinishSlidingInput();
 
-    /**
-     * Send a non-"code input" custom request to the listener.
-     * @return true if the request has been consumed, false otherwise.
-     */
+    /** Send a non-"code input" custom request to the listener. */
     boolean onCustomRequest(int requestCode);
 
-    /**
-     * Called when the user performs a horizontal or vertical swipe gesture
-     * on the space bar.
-     */
+    /** Swipes on space bar etc. */
     boolean onHorizontalSpaceSwipe(int steps);
     boolean onVerticalSpaceSwipe(int steps);
     void onEndSpaceSwipe();
@@ -125,55 +87,82 @@ public interface KeyboardActionListener {
     int SWIPE_HIDE_KEYBOARD = 4;
 
     class Adapter implements KeyboardActionListener {
+
         @Override
         public void onPressKey(int primaryCode, int repeatCount, boolean isSinglePointer, HapticEvent hapticEvent) {}
+
         @Override
         public void onLongPressKey(int primaryCode) {}
+
         @Override
         public void onReleaseKey(int primaryCode, boolean withSliding) {}
+
         @Override
         public boolean onKeyDown(int keyCode, KeyEvent keyEvent) { return false; }
+
         @Override
         public boolean onKeyUp(int keyCode, KeyEvent keyEvent) { return false; }
+
         @Override
         public void onCodeInput(int primaryCode, int x, int y, boolean isKeyRepeat) {}
+
         @Override
         public void onTextInput(String text) {}
+
         @Override
         public void onStartBatchInput() {}
+
         @Override
         public void onUpdateBatchInput(InputPointers batchPointers) {}
+
         @Override
         public void onEndBatchInput(InputPointers batchPointers) {}
+
         @Override
         public void onCancelBatchInput() {}
+
         @Override
         public void onCancelInput() {}
+
         @Override
         public void onFinishSlidingInput() {}
+
         @Override
         public boolean onCustomRequest(int requestCode) {
             return false;
         }
+
         @Override
         public boolean onHorizontalSpaceSwipe(int steps) {
             return false;
         }
+
         @Override
         public boolean onVerticalSpaceSwipe(int steps) {
             return false;
         }
+
         @Override
         public boolean toggleNumpad(boolean withSliding, boolean forceReturnToAlpha) {
             return false;
         }
+
         @Override
         public void onEndSpaceSwipe() {}
+
         @Override
         public void onMoveDeletePointer(int steps) {}
+
         @Override
         public void onUpWithDeletePointerActive() {}
+
         @Override
         public void resetMetaState() {}
+
+        @Override
+        public void onMoveFocus(Direction direction) {}
+
+        @Override
+        public void onPressFocusedKey() {}
     }
 }

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
@@ -60,7 +60,18 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
 
     override fun onReleaseKey(primaryCode: Int, withSliding: Boolean) {
         metaOnReleaseKey(primaryCode)
-        keyboardSwitcher.onReleaseKey(primaryCode, withSliding, latinIME.currentAutoCapsState, latinIME.currentRecapitalizeState)
+        keyboardSwitcher.onReleaseKey(primaryCode, withSliding,
+            latinIME.currentAutoCapsState, latinIME.currentRecapitalizeState)
+    }
+
+    override fun onMoveFocus(direction: KeyboardActionListener.Direction) {
+        val kv = KeyboardView.getActiveKeyboardView() ?: return
+        kv.moveFocus(direction)
+    }
+
+    override fun onPressFocusedKey() {
+        val kv = KeyboardView.getActiveKeyboardView() ?: return
+        kv.pressFocusedKey()
     }
 
     override fun onKeyUp(keyCode: Int, keyEvent: KeyEvent): Boolean {

--- a/app/src/main/java/helium314/keyboard/keyboard/MainKeyboardView.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/MainKeyboardView.java
@@ -31,6 +31,7 @@ import androidx.annotation.Nullable;
 import helium314.keyboard.accessibility.AccessibilityUtils;
 import helium314.keyboard.accessibility.MainKeyboardAccessibilityDelegate;
 import helium314.keyboard.compat.ConfigurationCompatKt;
+import helium314.keyboard.event.HapticEvent;
 import helium314.keyboard.keyboard.internal.DrawingPreviewPlacerView;
 import helium314.keyboard.keyboard.internal.DrawingProxy;
 import helium314.keyboard.keyboard.internal.GestureFloatingTextDrawingPreview;
@@ -282,7 +283,9 @@ public final class MainKeyboardView extends KeyboardView implements DrawingProxy
     public void setKeyboardActionListener(final KeyboardActionListener listener) {
         mKeyboardActionListener = listener;
         PointerTracker.setKeyboardActionListener(listener);
+        KeyboardView.setGlobalKeyboardActionListener(listener);
     }
+
 
     // TODO: We should reconsider which coordinate system should be used to represent keyboard event.
     public int getKeyX(final int x) {
@@ -841,6 +844,29 @@ public final class MainKeyboardView extends KeyboardView implements DrawingProxy
         paint.clearShadowLayer();
         paint.setTextScaleX(1.0f);
     }
+
+    @Override
+    public void pressFocusedKey() {
+        if (mFocusedKey == null || mKeyboardActionListener == null) {
+            return;
+        }
+
+        final Key key = mFocusedKey;
+        final int code = key.getCode();
+        if (code == 0) return;
+
+        final int centerX = key.getX() + key.getWidth() / 2;
+        final int centerY = key.getY() + key.getHeight() / 2;
+        final int keyX = getKeyX(centerX);
+        final int keyY = getKeyY(centerY);
+
+        mKeyboardActionListener.onPressKey(code, 0, true, HapticEvent.KEY_PRESS);
+        mKeyboardActionListener.onCodeInput(code, keyX, keyY, false);
+        mKeyboardActionListener.onReleaseKey(code, false);
+
+        invalidateKey(key);
+    }
+
 
     @Override
     public void deallocateMemory() {


### PR DESCRIPTION
This pull request introduces the groundwork for controlling the keyboard using an external input device, such as a TV remote. With these changes, the keyboard can now be navigated and interacted with through external control, improving accessibility and enabling new use cases beyond touch input.

Key points:

- Implemented logic in the keyboard core to support navigation and key selection via external devices.

- Changes improve integration with TV boxes, game consoles, or other remote-controlled environments.

- [ ] Navigating word suggestions and the emoji keyboard is not yet functional.

Modifications in EmojiPalettesAdapter and EmojiPalettesView are experimental and do not affect the normal operation of the keyboard.


This PR lays the foundation for full external control support while keeping standard touch-based functionality fully intact.