### PR TITLE
feat: configurable vibration amplitude on api >= 26

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/AppUpgrade.kt
+++ b/app/src/main/java/helium314/keyboard/latin/AppUpgrade.kt
@@ -603,12 +603,12 @@ object AppUpgrade {
             prefs.edit {
                 if (prefs.getBoolean(Settings.PREF_VIBRATE_ON, false))
                     if (prefs.getInt(Settings.PREF_VIBRATION_DURATION_SETTINGS, Defaults.PREF_VIBRATION_DURATION_SETTINGS) == -1) {
-                        putString(Settings.PREF_VIBRATION_TYPE, AudioAndHapticFeedbackManager.VibrationType.SYSTEM.value)
+                        putString(Settings.PREF_VIBRATION_TYPE, AudioAndHapticFeedbackManager.VibrationType.SYSTEM.toString())
                         putInt(Settings.PREF_VIBRATION_DURATION_SETTINGS, Defaults.PREF_VIBRATION_DURATION_SETTINGS)
                     }
                     else
-                        putString(Settings.PREF_VIBRATION_TYPE, AudioAndHapticFeedbackManager.VibrationType.CUSTOM.value)
-                else putString(Settings.PREF_VIBRATION_TYPE, AudioAndHapticFeedbackManager.VibrationType.OFF.value)
+                        putString(Settings.PREF_VIBRATION_TYPE, AudioAndHapticFeedbackManager.VibrationType.CUSTOM.toString())
+                else putString(Settings.PREF_VIBRATION_TYPE, AudioAndHapticFeedbackManager.VibrationType.OFF.toString())
                 remove(Settings.PREF_VIBRATE_ON)
             }
         }

--- a/app/src/main/java/helium314/keyboard/latin/AppUpgrade.kt
+++ b/app/src/main/java/helium314/keyboard/latin/AppUpgrade.kt
@@ -2,6 +2,7 @@ package helium314.keyboard.latin
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.SharedPreferences
 import androidx.core.content.edit
 import helium314.keyboard.compat.isDeviceLocked
 import helium314.keyboard.compat.isUserLocked
@@ -596,6 +597,19 @@ object AppUpgrade {
             prefs.edit {
                 putBoolean(Settings.PREF_SUGGEST_PUNCTUATION,
                     !prefs.getBoolean(Settings.PREF_BIGRAM_PREDICTIONS, Defaults.PREF_BIGRAM_PREDICTIONS))
+            }
+        }
+        if (prefs.contains(Settings.PREF_VIBRATE_ON)) {
+            prefs.edit {
+                if (prefs.getBoolean(Settings.PREF_VIBRATE_ON, false))
+                    if (prefs.getInt(Settings.PREF_VIBRATION_DURATION_SETTINGS, Defaults.PREF_VIBRATION_DURATION_SETTINGS) == -1) {
+                        putString(Settings.PREF_VIBRATION_TYPE, AudioAndHapticFeedbackManager.VibrationType.SYSTEM.value)
+                        putInt(Settings.PREF_VIBRATION_DURATION_SETTINGS, Defaults.PREF_VIBRATION_DURATION_SETTINGS)
+                    }
+                    else
+                        putString(Settings.PREF_VIBRATION_TYPE, AudioAndHapticFeedbackManager.VibrationType.CUSTOM.value)
+                else putString(Settings.PREF_VIBRATION_TYPE, AudioAndHapticFeedbackManager.VibrationType.OFF.value)
+                remove(Settings.PREF_VIBRATE_ON)
             }
         }
         upgradeToolbarPrefs(prefs)

--- a/app/src/main/java/helium314/keyboard/latin/AudioAndHapticFeedbackManager.java
+++ b/app/src/main/java/helium314/keyboard/latin/AudioAndHapticFeedbackManager.java
@@ -42,19 +42,9 @@ public final class AudioAndHapticFeedbackManager {
     }
 
     public enum VibrationType {
-        OFF("off"),
-        SYSTEM("system"),
-        CUSTOM("custom");
-
-        private final String value;
-
-        VibrationType(String value) {
-            this.value = value;
-        }
-
-        public String getValue() {
-            return value;
-        }
+        OFF,
+        SYSTEM,
+        CUSTOM;
     }
 
     private AudioAndHapticFeedbackManager() {

--- a/app/src/main/java/helium314/keyboard/latin/AudioAndHapticFeedbackManager.java
+++ b/app/src/main/java/helium314/keyboard/latin/AudioAndHapticFeedbackManager.java
@@ -41,6 +41,30 @@ public final class AudioAndHapticFeedbackManager {
         return sInstance;
     }
 
+    public enum VibrationType {
+        OFF("off"),
+        SYSTEM("system"),
+        CUSTOM("custom");
+
+        private final String value;
+
+        VibrationType(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public static VibrationType fromString(String value) {
+            try {
+                return VibrationType.valueOf(value.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                return VibrationType.OFF;
+            }
+        }
+    };
+
     private AudioAndHapticFeedbackManager() {
         // Intentional empty constructor for singleton.
     }
@@ -112,9 +136,9 @@ public final class AudioAndHapticFeedbackManager {
             // Avoid surprises with the handling of HapticFeedbackConstants.NO_HAPTICS
             return;
         }
-        if (mSettingsValues.mVibrationType.equals("custom") && hapticEvent.allowCustomDuration) {
+        if (mSettingsValues.mVibrationType == VibrationType.CUSTOM && hapticEvent.allowCustomDuration) {
             vibrate(mSettingsValues.mKeypressVibrationDuration, mSettingsValues.mKeypressVibrationAmplitude);
-        } else if (!mSettingsValues.mVibrationType.equals("off") && viewToPerformHapticFeedbackOn != null) {
+        } else if (mSettingsValues.mVibrationType != VibrationType.OFF && viewToPerformHapticFeedbackOn != null) {
             viewToPerformHapticFeedbackOn.performHapticFeedback(
                 hapticEvent.feedbackConstant,
                 HapticFeedbackConstants.FLAG_IGNORE_GLOBAL_SETTING);

--- a/app/src/main/java/helium314/keyboard/latin/AudioAndHapticFeedbackManager.java
+++ b/app/src/main/java/helium314/keyboard/latin/AudioAndHapticFeedbackManager.java
@@ -55,15 +55,7 @@ public final class AudioAndHapticFeedbackManager {
         public String getValue() {
             return value;
         }
-
-        public static VibrationType fromString(String value) {
-            try {
-                return VibrationType.valueOf(value.toUpperCase());
-            } catch (IllegalArgumentException e) {
-                return VibrationType.OFF;
-            }
-        }
-    };
+    }
 
     private AudioAndHapticFeedbackManager() {
         // Intentional empty constructor for singleton.

--- a/app/src/main/java/helium314/keyboard/latin/LatinIME.java
+++ b/app/src/main/java/helium314/keyboard/latin/LatinIME.java
@@ -1616,16 +1616,17 @@ public class LatinIME extends InputMethodService implements
             }
             // TODO: Use event time that the last feedback has been generated instead of relying on
             // a repeat count to thin out feedback.
-            if (repeatCount % PERIOD_FOR_AUDIO_AND_HAPTIC_FEEDBACK_IN_KEY_REPEAT == 0) {
-                return;
-            }
+
+//            if (repeatCount % PERIOD_FOR_AUDIO_AND_HAPTIC_FEEDBACK_IN_KEY_REPEAT == 0) {
+//                return;
+//            }
         }
         final AudioAndHapticFeedbackManager feedbackManager =
                 AudioAndHapticFeedbackManager.getInstance();
-        if (repeatCount == 0) {
+//        if (repeatCount == 0) {
             // TODO: Reconsider how to perform haptic feedback when repeating key.
             feedbackManager.performHapticFeedback(keyboardView, hapticEvent);
-        }
+//        }
         feedbackManager.performAudioFeedback(code, hapticEvent);
     }
 

--- a/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
@@ -51,7 +51,7 @@ object Defaults {
     const val PREF_CUSTOM_ICON_NAMES = ""
     const val PREF_TOOLBAR_CUSTOM_KEY_CODES = ""
     const val PREF_AUTO_CAP = true
-    const val PREF_VIBRATE_ON = false
+    const val PREF_VIBRATION_TYPE = "off"
     const val PREF_VIBRATE_IN_DND_MODE = false
     const val PREF_SOUND_ON = false
     const val PREF_SUGGEST_EMOJIS = true
@@ -105,7 +105,8 @@ object Defaults {
     const val PREF_SUGGEST_PUNCTUATION = false
     const val PREF_SUGGEST_CLIPBOARD_CONTENT = true
     const val PREF_GESTURE_INPUT = true
-    const val PREF_VIBRATION_DURATION_SETTINGS = -1
+    const val PREF_VIBRATION_DURATION_SETTINGS = 10
+    const val PREF_VIBRATION_AMPLITUDE_SETTINGS = 255
     const val PREF_KEYPRESS_SOUND_VOLUME = -0.01f
     const val PREF_KEY_LONGPRESS_TIMEOUT = 300
     const val PREF_ENABLE_EMOJI_ALT_PHYSICAL_KEY = true

--- a/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
@@ -6,6 +6,7 @@ import android.os.Build
 import android.util.TypedValue
 import android.view.Gravity
 import helium314.keyboard.keyboard.KeyboardTheme
+import helium314.keyboard.latin.AudioAndHapticFeedbackManager
 import helium314.keyboard.latin.BuildConfig
 import helium314.keyboard.latin.common.Constants.Separators
 import helium314.keyboard.latin.common.Constants.Subtype.ExtraValue
@@ -51,7 +52,8 @@ object Defaults {
     const val PREF_CUSTOM_ICON_NAMES = ""
     const val PREF_TOOLBAR_CUSTOM_KEY_CODES = ""
     const val PREF_AUTO_CAP = true
-    const val PREF_VIBRATION_TYPE = "off"
+    @JvmField
+    val PREF_VIBRATION_TYPE: String = AudioAndHapticFeedbackManager.VibrationType.OFF.value
     const val PREF_VIBRATE_IN_DND_MODE = false
     const val PREF_SOUND_ON = false
     const val PREF_SUGGEST_EMOJIS = true
@@ -105,8 +107,8 @@ object Defaults {
     const val PREF_SUGGEST_PUNCTUATION = false
     const val PREF_SUGGEST_CLIPBOARD_CONTENT = true
     const val PREF_GESTURE_INPUT = true
-    const val PREF_VIBRATION_DURATION_SETTINGS = 10
-    const val PREF_VIBRATION_AMPLITUDE_SETTINGS = 255
+    const val PREF_VIBRATION_DURATION_SETTINGS = 1
+    const val PREF_VIBRATION_AMPLITUDE_SETTINGS = 128
     const val PREF_KEYPRESS_SOUND_VOLUME = -0.01f
     const val PREF_KEY_LONGPRESS_TIMEOUT = 300
     const val PREF_ENABLE_EMOJI_ALT_PHYSICAL_KEY = true

--- a/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
@@ -53,7 +53,7 @@ object Defaults {
     const val PREF_TOOLBAR_CUSTOM_KEY_CODES = ""
     const val PREF_AUTO_CAP = true
     @JvmField
-    val PREF_VIBRATION_TYPE: String = AudioAndHapticFeedbackManager.VibrationType.OFF.value
+    val PREF_VIBRATION_TYPE: String = AudioAndHapticFeedbackManager.VibrationType.OFF.toString()
     const val PREF_VIBRATE_IN_DND_MODE = false
     const val PREF_SOUND_ON = false
     const val PREF_SUGGEST_EMOJIS = true

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -304,7 +304,8 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
 
     public static AudioAndHapticFeedbackManager.VibrationType readVibrationType(final SharedPreferences prefs) {
         return AudioAndHapticFeedbackManager.getInstance().hasVibrator()
-            ? AudioAndHapticFeedbackManager.VibrationType.fromString(prefs.getString(PREF_VIBRATION_TYPE, Defaults.PREF_VIBRATION_TYPE))
+            ? AudioAndHapticFeedbackManager.VibrationType.valueOf(
+                prefs.getString(PREF_VIBRATION_TYPE, Defaults.PREF_VIBRATION_TYPE).toUpperCase())
             : AudioAndHapticFeedbackManager.VibrationType.OFF;
     }
 

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -305,7 +305,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static AudioAndHapticFeedbackManager.VibrationType readVibrationType(final SharedPreferences prefs) {
         return AudioAndHapticFeedbackManager.getInstance().hasVibrator()
             ? AudioAndHapticFeedbackManager.VibrationType.valueOf(
-                prefs.getString(PREF_VIBRATION_TYPE, Defaults.PREF_VIBRATION_TYPE).toUpperCase())
+                prefs.getString(PREF_VIBRATION_TYPE, Defaults.PREF_VIBRATION_TYPE))
             : AudioAndHapticFeedbackManager.VibrationType.OFF;
     }
 

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -234,22 +234,6 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
         mContext = context;
         mPrefs = KtxKt.prefs(context);
         mPrefs.registerOnSharedPreferenceChangeListener(this);
-        migrateLegacyPreferences();
-    }
-
-    private void migrateLegacyPreferences() {
-        final var prefsEditor = mPrefs.edit();
-        if (mPrefs.contains(Settings.PREF_VIBRATE_ON)) {
-            if (mPrefs.getBoolean(Settings.PREF_VIBRATE_ON, false))
-                prefsEditor.putString(PREF_VIBRATION_TYPE,
-                    mPrefs.getInt(Settings.PREF_VIBRATION_DURATION_SETTINGS, Defaults.PREF_VIBRATION_DURATION_SETTINGS) == -1
-                        ? "system"
-                        : "custom");
-            else
-                prefsEditor.putString(PREF_VIBRATION_TYPE, "off");
-            prefsEditor.remove(Settings.PREF_VIBRATE_ON);
-        }
-        prefsEditor.apply();
     }
 
     public void onDestroy() {
@@ -318,10 +302,10 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
         return res.getInteger(R.integer.config_screen_metrics);
     }
 
-    public static String readVibrationType(final SharedPreferences prefs) {
+    public static AudioAndHapticFeedbackManager.VibrationType readVibrationType(final SharedPreferences prefs) {
         return AudioAndHapticFeedbackManager.getInstance().hasVibrator()
-            ? prefs.getString(PREF_VIBRATION_TYPE, Defaults.PREF_VIBRATION_TYPE)
-            : "off";
+            ? AudioAndHapticFeedbackManager.VibrationType.fromString(prefs.getString(PREF_VIBRATION_TYPE, Defaults.PREF_VIBRATION_TYPE))
+            : AudioAndHapticFeedbackManager.VibrationType.OFF;
     }
 
     public void toggleAutoCorrect() {

--- a/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
@@ -21,6 +21,7 @@ import androidx.core.util.TypedValueCompat;
 import helium314.keyboard.compat.ConfigurationCompatKt;
 import helium314.keyboard.keyboard.KeyboardTheme;
 import helium314.keyboard.keyboard.internal.keyboard_parser.LocaleKeyboardInfosKt;
+import helium314.keyboard.latin.AudioAndHapticFeedbackManager;
 import helium314.keyboard.latin.InputAttributes;
 import helium314.keyboard.latin.R;
 import helium314.keyboard.latin.RichInputMethodManager;
@@ -51,7 +52,7 @@ public class SettingsValues {
     public final int mDisplayOrientation;
     // From preferences
     public final boolean mAutoCap;
-    public final String mVibrationType;
+    public final AudioAndHapticFeedbackManager.VibrationType mVibrationType;
     public final boolean mVibrateInDndMode;
     public final boolean mSoundOn;
     public final boolean mSuggestEmojis;

--- a/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
@@ -51,7 +51,7 @@ public class SettingsValues {
     public final int mDisplayOrientation;
     // From preferences
     public final boolean mAutoCap;
-    public final boolean mVibrateOn;
+    public final String mVibrationType;
     public final boolean mVibrateInDndMode;
     public final boolean mSoundOn;
     public final boolean mSuggestEmojis;
@@ -141,6 +141,7 @@ public class SettingsValues {
     public final boolean mSuggestionStripHiddenPerUserSettings;
     public final boolean mSecondaryStripVisible;
     public final int mKeypressVibrationDuration;
+    public final int mKeypressVibrationAmplitude;
     public final float mKeypressSoundVolume;
     public final boolean mAutoCorrectionEnabledPerUserSettings;
     public final boolean mAutoCorrectEnabled;
@@ -172,7 +173,7 @@ public class SettingsValues {
         mToolbarMode = Settings.readToolbarMode(prefs);
         mToolbarHidingGlobal = prefs.getBoolean(Settings.PREF_TOOLBAR_HIDING_GLOBAL, Defaults.PREF_TOOLBAR_HIDING_GLOBAL);
         mAutoCap = prefs.getBoolean(Settings.PREF_AUTO_CAP, Defaults.PREF_AUTO_CAP) && ScriptUtils.scriptSupportsUppercase(mLocale);
-        mVibrateOn = Settings.readVibrationEnabled(prefs);
+        mVibrationType = Settings.readVibrationType(prefs);
         mVibrateInDndMode = prefs.getBoolean(Settings.PREF_VIBRATE_IN_DND_MODE, Defaults.PREF_VIBRATE_IN_DND_MODE);
         mSoundOn = prefs.getBoolean(Settings.PREF_SOUND_ON, Defaults.PREF_SOUND_ON);
         mSuggestEmojis = prefs.getBoolean(Settings.PREF_SUGGEST_EMOJIS, Defaults.PREF_SUGGEST_EMOJIS);
@@ -231,6 +232,7 @@ public class SettingsValues {
         // Compute other readable settings
         mKeyLongpressTimeout = prefs.getInt(Settings.PREF_KEY_LONGPRESS_TIMEOUT, Defaults.PREF_KEY_LONGPRESS_TIMEOUT);
         mKeypressVibrationDuration = prefs.getInt(Settings.PREF_VIBRATION_DURATION_SETTINGS, Defaults.PREF_VIBRATION_DURATION_SETTINGS);
+        mKeypressVibrationAmplitude = prefs.getInt(Settings.PREF_VIBRATION_AMPLITUDE_SETTINGS, Defaults.PREF_VIBRATION_AMPLITUDE_SETTINGS);
         mKeypressSoundVolume = prefs.getFloat(Settings.PREF_KEYPRESS_SOUND_VOLUME, Defaults.PREF_KEYPRESS_SOUND_VOLUME);
         mEnableEmojiAltPhysicalKey = prefs.getBoolean(Settings.PREF_ENABLE_EMOJI_ALT_PHYSICAL_KEY, Defaults.PREF_ENABLE_EMOJI_ALT_PHYSICAL_KEY);
         mGestureInputEnabled = JniUtils.sHaveGestureLib && prefs.getBoolean(Settings.PREF_GESTURE_INPUT, Defaults.PREF_GESTURE_INPUT);
@@ -384,8 +386,8 @@ public class SettingsValues {
         sb.append("" + mSpacingAndPunctuations.dump());
         sb.append("\n   mAutoCap = ");
         sb.append("" + mAutoCap);
-        sb.append("\n   mVibrateOn = ");
-        sb.append("" + mVibrateOn);
+        sb.append("\n   mVibrationType = ");
+        sb.append("" + mVibrationType);
         sb.append("\n   mSoundOn = ");
         sb.append("" + mSoundOn);
         sb.append("\n   mKeyPreviewPopupOn = ");
@@ -420,6 +422,8 @@ public class SettingsValues {
         sb.append("" + mInputAttributes);
         sb.append("\n   mKeypressVibrationDuration = ");
         sb.append("" + mKeypressVibrationDuration);
+        sb.append("\n   mKeypressVibrationAmplitude = ");
+        sb.append("" + mKeypressVibrationAmplitude);
         sb.append("\n   mKeypressSoundVolume = ");
         sb.append("" + mKeypressSoundVolume);
         sb.append("\n   mAutoCorrectEnabled = ");

--- a/app/src/main/java/helium314/keyboard/settings/screens/PreferencesScreen.kt
+++ b/app/src/main/java/helium314/keyboard/settings/screens/PreferencesScreen.kt
@@ -3,6 +3,7 @@ package helium314.keyboard.settings.screens
 
 import android.content.Context
 import android.media.AudioManager
+import android.os.Build
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -52,10 +53,13 @@ fun PreferencesScreen(
         Settings.PREF_SHOW_TLD_POPUP_KEYS,
         Settings.PREF_POPUP_ON,
         if (AudioAndHapticFeedbackManager.getInstance().hasVibrator())
-            Settings.PREF_VIBRATE_ON else null,
-        if (prefs.getBoolean(Settings.PREF_VIBRATE_ON, Defaults.PREF_VIBRATE_ON))
+            Settings.PREF_VIBRATION_TYPE else null,
+        if (prefs.getString(Settings.PREF_VIBRATION_TYPE, Defaults.PREF_VIBRATION_TYPE) == "custom")
             Settings.PREF_VIBRATION_DURATION_SETTINGS else null,
-        if (prefs.getBoolean(Settings.PREF_VIBRATE_ON, Defaults.PREF_VIBRATE_ON))
+        if (prefs.getString(Settings.PREF_VIBRATION_TYPE, Defaults.PREF_VIBRATION_TYPE) == "custom" &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+            Settings.PREF_VIBRATION_AMPLITUDE_SETTINGS else null,
+        if (prefs.getString(Settings.PREF_VIBRATION_TYPE, Defaults.PREF_VIBRATION_TYPE) != "off")
             Settings.PREF_VIBRATE_IN_DND_MODE else null,
         Settings.PREF_SOUND_ON,
         if (prefs.getBoolean(Settings.PREF_SOUND_ON, Defaults.PREF_SOUND_ON))
@@ -112,8 +116,16 @@ fun createPreferencesSettings(context: Context) = listOf(
     Setting(context, Settings.PREF_POPUP_ON, R.string.popup_on_keypress) {
         SwitchPreference(it, Defaults.PREF_POPUP_ON) { KeyboardSwitcher.getInstance().reloadKeyboard() }
     },
-    Setting(context, Settings.PREF_VIBRATE_ON, R.string.vibrate_on_keypress) {
-        SwitchPreference(it, Defaults.PREF_VIBRATE_ON)
+    Setting(context, Settings.PREF_VIBRATION_TYPE, R.string.vibrate_on_keypress) {
+        ListPreference(
+            it,
+            listOf(
+                stringResource(R.string.prefs_keypress_vibration_mode_off) to "off",
+                stringResource(R.string.prefs_keypress_vibration_mode_system) to "system",
+                stringResource(R.string.prefs_keypress_vibration_mode_custom) to "custom"
+            ),
+            Defaults.PREF_VIBRATION_TYPE
+        )
     },
     Setting(context, Settings.PREF_VIBRATE_IN_DND_MODE, R.string.vibrate_in_dnd_mode) {
         SwitchPreference(it, Defaults.PREF_VIBRATE_IN_DND_MODE)
@@ -192,8 +204,34 @@ fun createPreferencesSettings(context: Context) = listOf(
                 if (it < 0) stringResource(R.string.settings_system_default)
                 else stringResource(R.string.abbreviation_unit_milliseconds, it.toString())
             },
-            range = -1f..100f,
-            onValueChanged = { it?.let { AudioAndHapticFeedbackManager.getInstance().vibrate(it.toLong()) } }
+            range = 0f..100f,
+            onValueChanged = {
+                it?.let {
+                    AudioAndHapticFeedbackManager.getInstance().vibrate(
+                        it.toLong(),
+                        Settings.getInstance().current.mKeypressVibrationAmplitude
+                    )
+                }
+            }
+        )
+    },
+    Setting(context, Settings.PREF_VIBRATION_AMPLITUDE_SETTINGS, R.string.prefs_keypress_vibration_amplitude_settings) { setting ->
+        SliderPreference(
+            name = setting.title,
+            key = setting.key,
+            default = Defaults.PREF_VIBRATION_AMPLITUDE_SETTINGS,
+            description = {
+                if (it == 255) stringResource(R.string.settings_system_default)
+                else it.toString()
+            },
+            range = 0f..255f,
+            onValueChanged = {
+                it?.let {
+                    AudioAndHapticFeedbackManager.getInstance().vibrate(
+                        Settings.getInstance().current.mKeypressVibrationDuration.toLong(), it.toInt()
+                    )
+                }
+            }
         )
     },
     Setting(context, Settings.PREF_KEYPRESS_SOUND_VOLUME, R.string.prefs_keypress_sound_volume_settings) { setting ->

--- a/app/src/main/java/helium314/keyboard/settings/screens/PreferencesScreen.kt
+++ b/app/src/main/java/helium314/keyboard/settings/screens/PreferencesScreen.kt
@@ -121,9 +121,9 @@ fun createPreferencesSettings(context: Context) = listOf(
         ListPreference(
             it,
             listOf(
-                stringResource(R.string.prefs_keypress_vibration_mode_off) to AudioAndHapticFeedbackManager.VibrationType.OFF.value,
-                stringResource(R.string.prefs_keypress_vibration_mode_system) to AudioAndHapticFeedbackManager.VibrationType.SYSTEM.value,
-                stringResource(R.string.prefs_keypress_vibration_mode_custom) to AudioAndHapticFeedbackManager.VibrationType.CUSTOM.value,
+                stringResource(R.string.prefs_keypress_vibration_mode_off) to AudioAndHapticFeedbackManager.VibrationType.OFF.toString(),
+                stringResource(R.string.prefs_keypress_vibration_mode_system) to AudioAndHapticFeedbackManager.VibrationType.SYSTEM.toString(),
+                stringResource(R.string.prefs_keypress_vibration_mode_custom) to AudioAndHapticFeedbackManager.VibrationType.CUSTOM.toString(),
             ),
             Defaults.PREF_VIBRATION_TYPE
         )

--- a/app/src/main/java/helium314/keyboard/settings/screens/PreferencesScreen.kt
+++ b/app/src/main/java/helium314/keyboard/settings/screens/PreferencesScreen.kt
@@ -43,6 +43,7 @@ fun PreferencesScreen(
     if ((b?.value ?: 0) < 0)
         Log.v("irrelevant", "stupid way to trigger recomposition on preference change")
     val clipboardHistoryEnabled = prefs.getBoolean(Settings.PREF_ENABLE_CLIPBOARD_HISTORY, Defaults.PREF_ENABLE_CLIPBOARD_HISTORY)
+    val vibrationType = Settings.readVibrationType(prefs);
     val items = listOf(
         R.string.settings_category_input,
         Settings.PREF_SHOW_HINTS,
@@ -54,12 +55,12 @@ fun PreferencesScreen(
         Settings.PREF_POPUP_ON,
         if (AudioAndHapticFeedbackManager.getInstance().hasVibrator())
             Settings.PREF_VIBRATION_TYPE else null,
-        if (prefs.getString(Settings.PREF_VIBRATION_TYPE, Defaults.PREF_VIBRATION_TYPE) == "custom")
+        if (vibrationType == AudioAndHapticFeedbackManager.VibrationType.CUSTOM)
             Settings.PREF_VIBRATION_DURATION_SETTINGS else null,
-        if (prefs.getString(Settings.PREF_VIBRATION_TYPE, Defaults.PREF_VIBRATION_TYPE) == "custom" &&
+        if (vibrationType == AudioAndHapticFeedbackManager.VibrationType.CUSTOM &&
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
             Settings.PREF_VIBRATION_AMPLITUDE_SETTINGS else null,
-        if (prefs.getString(Settings.PREF_VIBRATION_TYPE, Defaults.PREF_VIBRATION_TYPE) != "off")
+        if (vibrationType != AudioAndHapticFeedbackManager.VibrationType.OFF)
             Settings.PREF_VIBRATE_IN_DND_MODE else null,
         Settings.PREF_SOUND_ON,
         if (prefs.getBoolean(Settings.PREF_SOUND_ON, Defaults.PREF_SOUND_ON))
@@ -120,9 +121,9 @@ fun createPreferencesSettings(context: Context) = listOf(
         ListPreference(
             it,
             listOf(
-                stringResource(R.string.prefs_keypress_vibration_mode_off) to "off",
-                stringResource(R.string.prefs_keypress_vibration_mode_system) to "system",
-                stringResource(R.string.prefs_keypress_vibration_mode_custom) to "custom"
+                stringResource(R.string.prefs_keypress_vibration_mode_off) to AudioAndHapticFeedbackManager.VibrationType.OFF.value,
+                stringResource(R.string.prefs_keypress_vibration_mode_system) to AudioAndHapticFeedbackManager.VibrationType.SYSTEM.value,
+                stringResource(R.string.prefs_keypress_vibration_mode_custom) to AudioAndHapticFeedbackManager.VibrationType.CUSTOM.value,
             ),
             Defaults.PREF_VIBRATION_TYPE
         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -546,8 +546,13 @@ language, hence "No language". -->
     <string name="day_or_night_day">Day</string>
     <!-- Button for selecting night -->
     <string name="day_or_night_night">Night</string>
+    <string name="prefs_keypress_vibration_mode_off">Off</string>
+    <string name="prefs_keypress_vibration_mode_system">System</string>
+    <string name="prefs_keypress_vibration_mode_custom">Custom</string>
     <!-- Title of the setting for keypress vibration duration -->
     <string name="prefs_keypress_vibration_duration_settings">Keypress vibration duration</string>
+    <!-- Title of the setting for keypress vibration amplitude -->
+    <string name="prefs_keypress_vibration_amplitude_settings">Keypress vibration amplitude</string>
     <!-- Title of the setting for keypress sound volume -->
     <string name="prefs_keypress_sound_volume_settings">Keypress sound volume</string>
     <!-- Title of the setting for key long press delay -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -547,12 +547,12 @@ language, hence "No language". -->
     <!-- Button for selecting night -->
     <string name="day_or_night_night">Night</string>
     <string name="prefs_keypress_vibration_mode_off">Off</string>
-    <string name="prefs_keypress_vibration_mode_system">System</string>
+    <string name="prefs_keypress_vibration_mode_system">System default</string>
     <string name="prefs_keypress_vibration_mode_custom">Custom</string>
     <!-- Title of the setting for keypress vibration duration -->
     <string name="prefs_keypress_vibration_duration_settings">Keypress vibration duration</string>
     <!-- Title of the setting for keypress vibration amplitude -->
-    <string name="prefs_keypress_vibration_amplitude_settings">Keypress vibration amplitude</string>
+    <string name="prefs_keypress_vibration_amplitude_settings">Keypress vibration intensity</string>
     <!-- Title of the setting for keypress sound volume -->
     <string name="prefs_keypress_sound_volume_settings">Keypress sound volume</string>
     <!-- Title of the setting for key long press delay -->


### PR DESCRIPTION
Hey! First, thanks for the app, it's absolutely great! <3

This PR introduces an option to change vibration amplitude (maybe the user-facing name should be changed to something more appropriate). Here is what I have done:
* Added a submenu to the `PreferencesScreen` to easily toggle between `off`/`system`/`custom` vibration modes, this also allows to simplify the logic.
* Implemented a migration mechanism, so that these changes won't affect current users.

I've also made sure to test the vibration related functions, and they appear to be working correctly.

Again, thanks for your time, your work is greatly appreciated!