### PR TITLE
Fix backspace to delete composing chars in Khipro layout

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/WordComposer.java
+++ b/app/src/main/java/helium314/keyboard/latin/WordComposer.java
@@ -150,6 +150,10 @@ public final class WordComposer {
         // The retained state of the combiner chain may have changed while processing the event,
         // so we need to update our cache.
         refreshTypedWordCache();
+        // Sync cursor position when word becomes empty (prevents crash when combiner commits)
+        if (mCodePointSize == 0) {
+            mCursorPositionWithinWord = 0;
+        }
         mEvents.add(event);
         return processedEvent;
     }


### PR DESCRIPTION
Previously, pressing backspace while composing Bengali text with the Khipro layout would incorrectly commit the entire word to the text field instead of deleting characters one-by-one. This fix adds proper DELETE key handling to BnKhiproCombiner that removes characters from the composing buffer (preedit), and when the last character is deleted, cleanly commits the word by returning a SPACE event. Additionally, a safety check in WordComposer synchronizes the cursor position when the word becomes empty, preventing a crash caused by the cursor position being out of sync with the code point size.
