### PR TITLE
Add option to toggle hardware keyboard support in settings

### DIFF
--- a/app/src/main/java/helium314/keyboard/event/HardwareKeyboardEventDecoder.kt
+++ b/app/src/main/java/helium314/keyboard/event/HardwareKeyboardEventDecoder.kt
@@ -10,6 +10,7 @@ import android.view.KeyCharacterMap
 import android.view.KeyEvent
 import helium314.keyboard.keyboard.internal.keyboard_parser.floris.KeyCode
 import helium314.keyboard.latin.common.Constants
+import helium314.keyboard.latin.utils.Log
 
 /**
  * A hardware event decoder for a hardware qwerty-ish keyboard.
@@ -26,6 +27,11 @@ class HardwareKeyboardEventDecoder(val mDeviceId: Int) : HardwareEventDecoder {
         // hence the name "codePointAndFlags". {@see KeyEvent#getUnicodeChar()} for more info.
         val codePointAndFlags = keyEvent.unicodeChar.takeIf { it != 0 }
             ?: Event.NOT_A_CODE_POINT // KeyEvent has 0 if no codePoint, but that's actually valid so we convert it to -1
+
+        // Debug logging to understand hardware keyboard behavior
+        val charFromEvent = if (codePointAndFlags > 0) codePointAndFlags.toChar() else '?'
+        Log.d("HWKeyboard", "keyCode=${keyEvent.keyCode}, unicodeChar=${keyEvent.unicodeChar}, " +
+            "char='$charFromEvent', deviceId=${keyEvent.deviceId}, scanCode=${keyEvent.scanCode}")
 
         // The keyCode is the abstraction used by the KeyEvent to represent different keys that
         // do not necessarily map to a unicode character. This represents a physical key, like

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
@@ -22,7 +22,6 @@ import helium314.keyboard.latin.common.StringUtils
 import helium314.keyboard.latin.common.combiningRange
 import helium314.keyboard.latin.common.loopOverCodePoints
 import helium314.keyboard.latin.common.loopOverCodePointsBackwards
-import helium314.keyboard.latin.define.ProductionFlags
 import helium314.keyboard.latin.inputlogic.InputLogic
 import helium314.keyboard.latin.settings.Settings
 import helium314.keyboard.latin.utils.SubtypeSettings
@@ -65,7 +64,7 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
 
     override fun onKeyUp(keyCode: Int, keyEvent: KeyEvent): Boolean {
         emojiAltPhysicalKeyDetector.onKeyUp(keyEvent)
-        if (!ProductionFlags.IS_HARDWARE_KEYBOARD_SUPPORTED)
+        if (!settings.current.mEnableHardwareKeyboard)
             return false
 
         val keyIdentifier = keyEvent.deviceId.toLong() shl 32 + keyEvent.keyCode
@@ -74,7 +73,7 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
 
     override fun onKeyDown(keyCode: Int, keyEvent: KeyEvent): Boolean {
         emojiAltPhysicalKeyDetector.onKeyDown(keyEvent)
-        if (!ProductionFlags.IS_HARDWARE_KEYBOARD_SUPPORTED)
+        if (!settings.current.mEnableHardwareKeyboard)
             return false
 
         val event: Event

--- a/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
@@ -109,6 +109,7 @@ object Defaults {
     const val PREF_KEYPRESS_SOUND_VOLUME = -0.01f
     const val PREF_KEY_LONGPRESS_TIMEOUT = 300
     const val PREF_ENABLE_EMOJI_ALT_PHYSICAL_KEY = true
+    const val PREF_ENABLE_HARDWARE_KEYBOARD = false
     const val PREF_GESTURE_PREVIEW_TRAIL = true
     const val PREF_GESTURE_FLOATING_PREVIEW_TEXT = true
     const val PREF_GESTURE_FLOATING_PREVIEW_DYNAMIC = true

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -119,6 +119,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_KEYPRESS_SOUND_VOLUME = "keypress_sound_volume";
     public static final String PREF_KEY_LONGPRESS_TIMEOUT = "key_longpress_timeout";
     public static final String PREF_ENABLE_EMOJI_ALT_PHYSICAL_KEY = "enable_emoji_alt_physical_key";
+    public static final String PREF_ENABLE_HARDWARE_KEYBOARD = "enable_hardware_keyboard";
     public static final String PREF_GESTURE_PREVIEW_TRAIL = "gesture_preview_trail";
     public static final String PREF_GESTURE_FLOATING_PREVIEW_TEXT = "gesture_floating_preview_text";
     public static final String PREF_GESTURE_FLOATING_PREVIEW_DYNAMIC = "gesture_floating_preview_dynamic";

--- a/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
@@ -107,6 +107,7 @@ public class SettingsValues {
     public final boolean mSlidingKeyInputPreviewEnabled;
     public final int mKeyLongpressTimeout;
     public final boolean mEnableEmojiAltPhysicalKey;
+    public final boolean mEnableHardwareKeyboard;
     public final boolean mIsSplitKeyboardEnabled;
     public final float mSplitKeyboardSpacerRelativeWidth;
     public final boolean mQuickPinToolbarKeys;
@@ -233,6 +234,7 @@ public class SettingsValues {
         mKeypressVibrationDuration = prefs.getInt(Settings.PREF_VIBRATION_DURATION_SETTINGS, Defaults.PREF_VIBRATION_DURATION_SETTINGS);
         mKeypressSoundVolume = prefs.getFloat(Settings.PREF_KEYPRESS_SOUND_VOLUME, Defaults.PREF_KEYPRESS_SOUND_VOLUME);
         mEnableEmojiAltPhysicalKey = prefs.getBoolean(Settings.PREF_ENABLE_EMOJI_ALT_PHYSICAL_KEY, Defaults.PREF_ENABLE_EMOJI_ALT_PHYSICAL_KEY);
+        mEnableHardwareKeyboard = prefs.getBoolean(Settings.PREF_ENABLE_HARDWARE_KEYBOARD, Defaults.PREF_ENABLE_HARDWARE_KEYBOARD);
         mGestureInputEnabled = JniUtils.sHaveGestureLib && prefs.getBoolean(Settings.PREF_GESTURE_INPUT, Defaults.PREF_GESTURE_INPUT);
         mGestureTrailEnabled = prefs.getBoolean(Settings.PREF_GESTURE_PREVIEW_TRAIL, Defaults.PREF_GESTURE_PREVIEW_TRAIL);
         mGestureFloatingPreviewTextEnabled = !mInputAttributes.mDisableGestureFloatingPreviewText

--- a/app/src/main/java/helium314/keyboard/settings/screens/AdvancedScreen.kt
+++ b/app/src/main/java/helium314/keyboard/settings/screens/AdvancedScreen.kt
@@ -74,6 +74,7 @@ fun AdvancedSettingsScreen(
         Settings.PREF_SPACE_TO_CHANGE_LANG,
         Settings.PREFS_LONG_PRESS_SYMBOLS_FOR_NUMPAD,
         Settings.PREF_ENABLE_EMOJI_ALT_PHYSICAL_KEY,
+        Settings.PREF_ENABLE_HARDWARE_KEYBOARD,
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) Settings.PREF_SHOW_SETUP_WIZARD_ICON else null,
         Settings.PREF_ABC_AFTER_SYMBOL_SPACE,
         Settings.PREF_ABC_AFTER_NUMPAD_SPACE,
@@ -157,6 +158,11 @@ fun createAdvancedSettings(context: Context) = listOf(
         R.string.prefs_enable_emoji_alt_physical_key_summary)
     {
         SwitchPreference(it, Defaults.PREF_ENABLE_EMOJI_ALT_PHYSICAL_KEY)
+    },
+    Setting(context, Settings.PREF_ENABLE_HARDWARE_KEYBOARD, R.string.prefs_enable_hardware_keyboard,
+        R.string.prefs_enable_hardware_keyboard_summary)
+    {
+        SwitchPreference(it, Defaults.PREF_ENABLE_HARDWARE_KEYBOARD)
     },
     Setting(context, Settings.PREF_SHOW_SETUP_WIZARD_ICON, R.string.show_setup_wizard_icon, R.string.show_setup_wizard_icon_summary) {
         val ctx = LocalContext.current

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -560,6 +560,10 @@ language, hence "No language". -->
     <string name="prefs_enable_emoji_alt_physical_key">Emoji for physical keyboard</string>
     <!-- Description of the settings for enabling Emoji palette triggered by the Alt key on physical keyboards -->
     <string name="prefs_enable_emoji_alt_physical_key_summary">Physical Alt key shows the emoji palette</string>
+    <!-- Title of the setting for enabling hardware keyboard support -->
+    <string name="prefs_enable_hardware_keyboard">Hardware keyboard support</string>
+    <!-- Description of the setting for enabling hardware keyboard support -->
+    <string name="prefs_enable_hardware_keyboard_summary">Enable handling of physical keyboard input (experimental, may have issues)</string>
     <!-- Title of the button to revert to the default value of the device in the settings dialog. Preferably 10 characters or less. -->
     <string name="button_default">Default</string>
     <!-- Title of the setup wizard welcome screen. %s is the application name. -->


### PR DESCRIPTION
Add toggle for hardware keyboard support

# Summary

  This PR adds a user-facing setting to enable/disable hardware keyboard support, replacing the hardcoded ProductionFlags.IS_HARDWARE_KEYBOARD_SUPPORTED = false flag.

  Hardware keyboard support was disabled in v3.3 due to multiple issues (#1949, #1957, #2001, #2030, #2047). However, some users with physical keyboards need this functionality and are willing to accept potential issues. This change makes the feature opt-in rather than completely unavailable.

# Changes

  - Added new preference PREF_ENABLE_HARDWARE_KEYBOARD (default: false)
  - Added toggle in Advanced settings: "Hardware keyboard support"
  - Summary text warns users: "Enable handling of physical keyboard input (experimental, may have issues)"
  - KeyboardActionListenerImpl now checks the setting instead of the production flag
  - Added debug logging in HardwareKeyboardEventDecoder for troubleshooting

# Testing

  Tested with Croatian QWERTZ physical keyboard layout. Special characters (č, ć, ž, š, đ) work correctly when:
  1. Setting is enabled in HeliBoard
  2. Correct layout is configured in Android's physical keyboard settings

# Related issues

  Partially addresses #1949, #1957 by giving users the option to enable hardware keyboard support despite known issues.