### PR TITLE
Enable predictive back gesture 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@ SPDX-License-Identifier: Apache-2.0 AND GPL-3.0-only
             android:allowBackup="true"
             android:defaultToDeviceProtectedStorage="true"
             android:directBootAware="true"
+            android:enableOnBackInvokedCallback="true"
             tools:remove="android:appComponentFactory"
             tools:targetApi="p">
 


### PR DESCRIPTION
Hey there :)

This PR enables Android's [predictive back gesture](https://developer.android.com/guide/navigation/custom-back/predictive-back-gesture) for the keyboard! This gesture/animation has been live in Gboard since sometime in 2024.

I tested this on-device using a Google Pixel 9 running GrapheneOS based on Android 16.

| Before     | After      |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/50705191-948a-4dff-8e84-5eb477510e38" /> | <video src="https://github.com/user-attachments/assets/ea23eba0-61a0-4925-bb0b-2d4e83cf2d4c"/> |