### PR TITLE
Show language switch key when using system languages

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
@@ -353,7 +353,7 @@ public class SettingsValues {
             return imm.hasMultipleEnabledIMEsOrSubtypes(false /* include aux subtypes */);
         }
         if (!mLanguageSwitchKeyToOtherImes) {
-            return imm.hasMultipleEnabledSubtypesInThisIme(false /* include aux subtypes */);
+            return imm.hasMultipleEnabledSubtypesInThisIme(true /* include aux subtypes */);
         }
         return imm.hasMultipleEnabledSubtypesInThisIme(false /* include aux subtypes */)
             || imm.hasMultipleEnabledIMEsOrSubtypes(false /* include aux subtypes */);


### PR DESCRIPTION
Currently, if you select no languages in HeliBoard, which then defaults to system languages, the language switch key is not shown.

Fixes #2268.
