### PR TITLE
Apply custom font to suggestions bar

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripLayoutHelper.java
+++ b/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripLayoutHelper.java
@@ -470,6 +470,7 @@ final class SuggestionStripLayoutHelper {
         int count = 0;
         int indexInSuggestedWords;
         final Typeface emojiTypeface = Settings.getInstance().getCustomEmojiTypeface();
+        final Typeface customTypeface = Settings.getInstance().getCustomTypeface();
         for (indexInSuggestedWords = 0; indexInSuggestedWords < suggestedWords.size()
                 && count < maxSuggestionInStrip; indexInSuggestedWords++) {
             final int positionInStrip =
@@ -486,7 +487,8 @@ final class SuggestionStripLayoutHelper {
 
             if (emojiTypeface != null && StringUtilsKt.isEmoji(wordView.getText()))
                 wordView.setTypeface(emojiTypeface);
-            else wordView.setTypeface(Typeface.DEFAULT); // todo: maybe use user-provided typeface here?
+            else if (customTypeface != null) wordView.setTypeface(customTypeface);
+            else wordView.setTypeface(Typeface.DEFAULT);
             if (SuggestionStripView.DEBUG_SUGGESTIONS) {
                 mDebugInfoViews.get(positionInStrip).setText(suggestedWords.getDebugString(indexInSuggestedWords));
             }


### PR DESCRIPTION
The suggestion strip was ignoring the user's custom font setting and always falling back to the default typeface. This fix retrieves the configured custom typeface from settings and applies it to suggestion text when available.

The implementation follows the same pattern as emoji typeface handling: emoji text uses the emoji font, otherwise the custom typeface is applied if configured, and finally falls back to the default typeface.

Fixes #2314