### PR TITLE
Add slash to w key for Italian keyboard

### DIFF
--- a/app/src/main/assets/locale_key_texts/it.txt
+++ b/app/src/main/assets/locale_key_texts/it.txt
@@ -4,6 +4,7 @@ e è é ə ɜ
 i ì
 o ò ó º
 u ù
+w / \\
 
 [tlds]
 it gov.it edu.it


### PR DESCRIPTION
Fixes #2323 by adding slash and backslash as alternatives on the w key in Italian.