### PR TITLE
Add verification info

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Does not use internet permission, and thus is 100% offline.
 [<img src="https://user-images.githubusercontent.com/663460/26973090-f8fdc986-4d14-11e7-995a-e7c5e79ed925.png" alt="Get APK from GitHub" height="80">](https://github.com/Helium314/HeliBoard/releases/latest)
 [<img src="https://gitlab.com/IzzyOnDroid/repo/-/raw/master/assets/IzzyOnDroid.png" alt="Get it on IzzyOnDroid" height="80">](https://apt.izzysoft.de/fdroid/index/apk/helium314.keyboard)
 
+Verification info:
+- Package ID: `helium314.keyboard`
+- SHA-256 signing certificate hash: `TODO`
+
 ## Table of Contents
 
 - [Features](#features)


### PR DESCRIPTION
Provides a way to verify obtained checking signing cert hash. **Signing cert hash does not provided in that PR, HeliBoard developer needs to provide it on their own.** 

How to obtain signing cert hash? Simple: using `keytool` command line tool: `keytool -list -v -keystore path/to/keystore.jks` (you will be asked to provide password)
- you need to know keystore location. also if you used multiple keys you get multiple keys info instead of one.
- you will get output like, and you just need to take what goes after SHA256:

```
Valid from: <datetime from datetime to>
Certificate fingerprints:
         SHA1: <value>
         SHA256: <another value>
Signature algorithm name: <some signature algorithm name>
```

keytool usually comes with JDK, in JDK bin folder, see http://stackoverflow.com/questions/5488339/how-can-i-find-and-run-the-keytool

**Again, please provide signing key hash on your own using `keytool` and modifying this PR.**

Closes #1852