### PR TITLE
Feature: vibrate for repeated inputs #381

### DIFF
--- a/app/src/main/java/helium314/keyboard/event/HapticEvent.kt
+++ b/app/src/main/java/helium314/keyboard/event/HapticEvent.kt
@@ -14,6 +14,7 @@ enum class HapticEvent(@JvmField val feedbackConstant: Int, @JvmField val allowC
 //        ?
 //    ),
     KEY_LONG_PRESS(HapticFeedbackConstants.LONG_PRESS, true),
+    KEY_REPEAT(HapticFeedbackConstants.KEYBOARD_TAP, allowCustomDuration = false),
 //    GESTURE_START(
 //        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
 //            HapticFeedbackConstants.GESTURE_START

--- a/app/src/main/java/helium314/keyboard/event/HapticEvent.kt
+++ b/app/src/main/java/helium314/keyboard/event/HapticEvent.kt
@@ -14,7 +14,6 @@ enum class HapticEvent(@JvmField val feedbackConstant: Int, @JvmField val allowC
 //        ?
 //    ),
     KEY_LONG_PRESS(HapticFeedbackConstants.LONG_PRESS, true),
-//    KEY_REPEAT(HapticFeedbackConstants.?, ?),
 //    GESTURE_START(
 //        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
 //            HapticFeedbackConstants.GESTURE_START

--- a/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PointerTracker.java
@@ -290,7 +290,8 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
             return false;
         }
         if (key.isEnabled()) {
-            sListener.onPressKey(key.getCode(), repeatCount, getActivePointerTrackerCount() == 1, HapticEvent.KEY_PRESS);
+            final HapticEvent hapticEvent = repeatCount == 0 ? HapticEvent.KEY_PRESS : HapticEvent.KEY_REPEAT;
+            sListener.onPressKey(key.getCode(), repeatCount, getActivePointerTrackerCount() == 1, hapticEvent);
             final boolean keyboardLayoutHasBeenChanged = mKeyboardLayoutHasBeenChanged;
             mKeyboardLayoutHasBeenChanged = false;
             sTimerProxy.startTypingStateTimer(key);

--- a/app/src/main/java/helium314/keyboard/latin/LatinIME.java
+++ b/app/src/main/java/helium314/keyboard/latin/LatinIME.java
@@ -1646,10 +1646,8 @@ public class LatinIME extends InputMethodService implements
         }
         final AudioAndHapticFeedbackManager feedbackManager =
                 AudioAndHapticFeedbackManager.getInstance();
-        if (repeatCount == 0) {
-            // TODO: Reconsider how to perform haptic feedback when repeating key.
-            feedbackManager.performHapticFeedback(keyboardView, hapticEvent);
-        }
+
+        feedbackManager.performHapticFeedback(keyboardView, hapticEvent);
         feedbackManager.performAudioFeedback(code, hapticEvent);
     }
 


### PR DESCRIPTION
This is primarily noticeable when holding the delete key to delete multiple characters or when using the keyboard to move the cursor.

This implements the desired behavior of #381. It does not implement the vibrate on paste behavior mentioned further down the issue.

The change is remarkably simple. Just perform haptics on repeat key presses. It works great for delete and swipe at low and high vibration durations on my test phone (Pixel 3a). And holding other keys doesn't trigger a repeat since they  have a long press handler.
