### PR TITLE
fix: add work-arounds for additional Firefox forks

### DIFF
--- a/app/src/main/java/helium314/keyboard/compat/AppWorkarounds.kt
+++ b/app/src/main/java/helium314/keyboard/compat/AppWorkarounds.kt
@@ -9,7 +9,8 @@ object AppWorkarounds {
     fun adjustInputType(inputType: Int, packageName: String?): Int {
         return when (packageName) {
             "org.mozilla.fennec_fdroid", "org.mozilla.fenix", "org.mozilla.firefox_beta", "org.mozilla.focus",
-            "org.mozilla.klar", "org.mozilla.firefox", "org.ironfoxoss.ironfox", "net.waterfox.android.release",
+            "org.mozilla.klar", "org.mozilla.firefox", "org.ironfoxoss.ironfox", "org.ironfoxoss.ironfox.nightly",
+            "org.torproject.torbrowser", "org.torproject.torbrowser_alpha", "net.waterfox.android.release",
             "io.github.forkmaintainers.iceraven", "com.zen.web.tools.browser" -> {
                 // Firefox and forks (assuming all of them) don't set these flags, so we want to force them for most text fields on websites
                 // missing TYPE_TEXT_VARIATION_WEB_EDIT_TEXT is strange, considering all text fields on web pages should set it


### PR DESCRIPTION
Adds support for:
- IronFox Nightly
- Tor Browser
- Tor Browser Alpha

