### PR TITLE
Centralize keyboard typeface resolution for custom font consistency

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardTypeface.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardTypeface.kt
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+package helium314.keyboard.keyboard
+
+import android.content.Context
+import android.graphics.Typeface
+import android.widget.TextView
+import androidx.compose.ui.text.font.FontFamily
+import helium314.keyboard.latin.common.isEmoji
+import helium314.keyboard.latin.settings.Settings
+
+object KeyboardTypeface {
+    private val lock = Any()
+
+    private var cachedCustomTypeface: Typeface? = null
+    private var cachedCustomFontFamily: FontFamily? = null
+    @Volatile
+    private var customTypefaceLoaded = false
+
+    private var cachedEmojiTypeface: Typeface? = null
+    @Volatile
+    private var emojiTypefaceLoaded = false
+
+    private fun loadCustomTypeface(context: Context): Typeface? {
+        return runCatching {
+            Typeface.createFromFile(Settings.getCustomFontFile(context))
+        }.getOrNull()
+    }
+
+    private fun loadCustomEmojiTypeface(context: Context): Typeface? {
+        return runCatching {
+            Typeface.createFromFile(Settings.getCustomEmojiFontFile(context))
+        }.getOrNull()
+    }
+
+    @JvmStatic
+    fun customTypeface(): Typeface? {
+        if (customTypefaceLoaded) return cachedCustomTypeface
+        val context = Settings.getCurrentContext() ?: return null
+        synchronized(lock) {
+            if (!customTypefaceLoaded) {
+                cachedCustomTypeface = loadCustomTypeface(context)
+                cachedCustomFontFamily = cachedCustomTypeface?.let(::FontFamily)
+                customTypefaceLoaded = true
+            }
+            return cachedCustomTypeface
+        }
+    }
+
+    @JvmStatic
+    fun emojiTypeface(): Typeface? {
+        if (emojiTypefaceLoaded) return cachedEmojiTypeface
+        val context = Settings.getCurrentContext() ?: return null
+        synchronized(lock) {
+            if (!emojiTypefaceLoaded) {
+                cachedEmojiTypeface = loadCustomEmojiTypeface(context)
+                emojiTypefaceLoaded = true
+            }
+            return cachedEmojiTypeface
+        }
+    }
+
+    @JvmStatic
+    fun customFontFamily(): FontFamily? {
+        if (!customTypefaceLoaded) customTypeface()
+        return cachedCustomFontFamily
+    }
+
+    @JvmStatic
+    fun resolve(
+        text: CharSequence?,
+        customTypeface: Typeface? = customTypeface(),
+        emojiTypeface: Typeface? = emojiTypeface(),
+        defaultTypeface: Typeface = Typeface.DEFAULT,
+    ): Typeface = if (emojiTypeface != null && text != null && isEmoji(text)) {
+        emojiTypeface
+    } else {
+        customTypeface ?: defaultTypeface
+    }
+
+    @JvmStatic
+    fun applyToTextView(
+        textView: TextView,
+        text: CharSequence? = textView.text,
+        customTypeface: Typeface? = customTypeface(),
+        emojiTypeface: Typeface? = emojiTypeface(),
+        defaultTypeface: Typeface = Typeface.DEFAULT,
+    ) {
+        textView.typeface = resolve(text, customTypeface, emojiTypeface, defaultTypeface)
+    }
+
+    @JvmStatic
+    fun applyToTextView(textView: TextView) {
+        applyToTextView(textView, textView.text, customTypeface(), emojiTypeface(), Typeface.DEFAULT)
+    }
+
+    @JvmStatic
+    fun applyToTextView(textView: TextView, text: CharSequence?, defaultTypeface: Typeface) {
+        applyToTextView(textView, text, customTypeface(), emojiTypeface(), defaultTypeface)
+    }
+
+    @JvmStatic
+    fun clearCache() {
+        synchronized(lock) {
+            cachedCustomTypeface = null
+            cachedCustomFontFamily = null
+            customTypefaceLoaded = false
+            cachedEmojiTypeface = null
+            emojiTypefaceLoaded = false
+        }
+    }
+}

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardView.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardView.java
@@ -148,8 +148,8 @@ public class KeyboardView extends View {
         keyAttr.recycle();
 
         mPaint.setAntiAlias(true);
-        mTypeface = Settings.getInstance().getCustomTypeface();
-        mEmojiTypeface = Settings.getInstance().getCustomEmojiTypeface();
+        mTypeface = KeyboardTypeface.customTypeface();
+        mEmojiTypeface = KeyboardTypeface.emojiTypeface();
         setFitsSystemWindows(true);
     }
 
@@ -392,8 +392,7 @@ public class KeyboardView extends View {
         float labelBaseline = centerY;
         final String label = key.getLabel();
         if (label != null) {
-            final Typeface typeface = mEmojiTypeface != null && StringUtilsKt.isEmoji(label) ? mEmojiTypeface : mTypeface;
-            paint.setTypeface(typeface == null ? key.selectTypeface(params) : typeface);
+            paint.setTypeface(KeyboardTypeface.resolve(label, mTypeface, mEmojiTypeface, key.selectTypeface(params)));
             paint.setTextSize(key.selectTextSize(params) * mFontSizeMultiplier);
             final float labelCharHeight = TypefaceUtils.getReferenceCharHeight(paint);
             final float labelCharWidth = TypefaceUtils.getReferenceCharWidth(paint);
@@ -463,8 +462,7 @@ public class KeyboardView extends View {
             paint.setTextSize(key.selectHintTextSize(params) * mFontSizeMultiplier); // maybe take sqrt to not have such extreme changes?
             paint.setColor(key.selectHintTextColor(params));
             // TODO: Should add a way to specify type face for hint letters
-            final Typeface typeface = mEmojiTypeface != null && StringUtilsKt.isEmoji(hintLabel) ? mEmojiTypeface : mTypeface;
-            paint.setTypeface(typeface == null ? Typeface.DEFAULT_BOLD : typeface);
+            paint.setTypeface(KeyboardTypeface.resolve(hintLabel, mTypeface, mEmojiTypeface, Typeface.DEFAULT_BOLD));
             blendAlpha(paint, params.mAnimAlpha);
             final float labelCharHeight = TypefaceUtils.getReferenceCharHeight(paint);
             final float labelCharWidth = TypefaceUtils.getReferenceCharWidth(paint);

--- a/app/src/main/java/helium314/keyboard/keyboard/PopupTextView.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/PopupTextView.java
@@ -7,7 +7,6 @@
 package helium314.keyboard.keyboard;
 
 import android.content.Context;
-import android.graphics.Typeface;
 import android.util.AttributeSet;
 import android.util.TypedValue;
 import android.view.Gravity;
@@ -26,7 +25,6 @@ import helium314.keyboard.latin.settings.Settings;
  */
 public class PopupTextView extends TextView implements PopupKeysPanel {
     private final int[] mCoordinates = CoordinateUtils.newInstance();
-    private final Typeface mTypeface;
     private Controller mController = EMPTY_CONTROLLER;
     private int mOriginX;
     private int mOriginY;
@@ -40,7 +38,6 @@ public class PopupTextView extends TextView implements PopupKeysPanel {
     public PopupTextView(final Context context, final AttributeSet attrs,
                          final int defStyle) {
         super(context, attrs, defStyle);
-        mTypeface = Settings.getInstance().getCustomTypeface();
     }
 
     public void setKeyDrawParams(Key key, KeyDrawParams drawParams) {
@@ -48,7 +45,7 @@ public class PopupTextView extends TextView implements PopupKeysPanel {
         Settings.getValues().mColors.setBackground(this, ColorType.KEY_PREVIEW_BACKGROUND);
         setTextColor(drawParams.mPreviewTextColor);
         setTextSize(TypedValue.COMPLEX_UNIT_PX, key.selectHintTextSize(drawParams) << 1);
-        setTypeface(mTypeface == null ? key.selectTypeface(drawParams) : mTypeface);
+        KeyboardTypeface.applyToTextView(this, this.getText(), key.selectTypeface(drawParams));
     }
 
     @Override

--- a/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardHistoryView.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardHistoryView.kt
@@ -18,6 +18,7 @@ import helium314.keyboard.keyboard.KeyboardActionListener
 import helium314.keyboard.keyboard.KeyboardId
 import helium314.keyboard.keyboard.KeyboardLayoutSet
 import helium314.keyboard.keyboard.KeyboardSwitcher
+import helium314.keyboard.keyboard.KeyboardTypeface
 import helium314.keyboard.keyboard.MainKeyboardView
 import helium314.keyboard.keyboard.PointerTracker
 import helium314.keyboard.keyboard.internal.KeyDrawParams
@@ -158,12 +159,12 @@ class ClipboardHistoryView @JvmOverloads constructor(
         val params = KeyDrawParams()
         params.updateParams(clipboardLayoutParams.bottomRowKeyboardHeight, keyVisualAttr)
         val settings = Settings.getInstance()
-        settings.getCustomTypeface()?.let { params.mTypeface = it }
+        KeyboardTypeface.customTypeface()?.let { params.mTypeface = it }
         setupClipKey(params)
         setupBottomRowKeyboard(editorInfo, keyboardActionListener)
 
         placeholderView.apply {
-            typeface = params.mTypeface
+            KeyboardTypeface.applyToTextView(this, text, params.mTypeface, null)
             setTextColor(params.mTextColor)
             setTextSize(TypedValue.COMPLEX_UNIT_PX, params.mLabelSize.toFloat() * 2)
         }

--- a/app/src/main/java/helium314/keyboard/keyboard/emoji/EmojiSearchActivity.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/emoji/EmojiSearchActivity.kt
@@ -36,6 +36,7 @@ import androidx.compose.foundation.text.selection.LocalTextSelectionColors
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextFieldDefaults
@@ -78,6 +79,7 @@ import helium314.keyboard.keyboard.KeyboardId
 import helium314.keyboard.keyboard.KeyboardLayoutSet
 import helium314.keyboard.keyboard.KeyboardSwitcher
 import helium314.keyboard.keyboard.KeyboardTheme
+import helium314.keyboard.keyboard.KeyboardTypeface
 import helium314.keyboard.keyboard.internal.KeyboardBuilder
 import helium314.keyboard.keyboard.internal.KeyboardParams
 import helium314.keyboard.keyboard.internal.keyboard_parser.EMOJI_HINT_LABEL
@@ -170,6 +172,7 @@ class EmojiSearchActivity : ComponentActivity() {
                             heightPx = it.size.height
                             heightDp = with(localDensity) { it.size.height.toDp() }
                         }) {
+                        val fontFamily = remember { KeyboardTypeface.customFontFamily() }
                         Row(modifier = Modifier.fillMaxWidth().height(30.dp)) {
                             IconButton(onClick = { cancel() }) {
                                 Icon(painter = painterResource(R.drawable.ic_arrow_back),
@@ -177,6 +180,7 @@ class EmojiSearchActivity : ComponentActivity() {
                                     tint = Color(colors.get(ColorType.EMOJI_KEY_TEXT)))
                             }
                             Text(text = stringResource(R.string.emoji_search_title), fontSize = 18.sp,
+                                fontFamily = fontFamily,
                                 color = Color(colors.get(ColorType.EMOJI_KEY_TEXT)),
                                 modifier = Modifier.fillMaxWidth().align(Alignment.CenterVertically))
                         }
@@ -193,11 +197,14 @@ class EmojiSearchActivity : ComponentActivity() {
                             unfocusedTrailingIconColor = Color(colors.get(ColorType.FUNCTIONAL_KEY_TEXT)),
                             unfocusedPlaceholderColor = lerp(Color(colors.get(ColorType.FUNCTIONAL_KEY_BACKGROUND)),
                                 Color(colors.get(ColorType.FUNCTIONAL_KEY_TEXT)), 0.5f))
-                        CompositionLocalProvider(LocalTextSelectionColors provides textFieldColors.textSelectionColors) {
+                        CompositionLocalProvider(
+                            LocalTextSelectionColors provides textFieldColors.textSelectionColors,
+                            LocalTextStyle provides LocalTextStyle.current.copy(fontFamily = fontFamily),
+                        ) {
                             BasicTextField(
                                 value = text,
                                 modifier = Modifier.fillMaxWidth().heightIn(20.dp, 30.dp).focusRequester(focusRequester),
-                                textStyle = TextStyle(textDirection = TextDirection.Content, color = textFieldColors.unfocusedTextColor),
+                                textStyle = TextStyle(fontFamily = fontFamily, textDirection = TextDirection.Content, color = textFieldColors.unfocusedTextColor),
                                 onValueChange = {
                                     text = it
                                     search(it.text)
@@ -224,7 +231,7 @@ class EmojiSearchActivity : ComponentActivity() {
                                     contentPadding = PaddingValues(2.dp),
                                     visualTransformation = VisualTransformation.None,
                                     innerTextField = it,
-                                    placeholder = { Text(stringResource(R.string.search_field_placeholder)) },
+                                    placeholder = { Text(stringResource(R.string.search_field_placeholder), fontFamily = fontFamily) },
                                     leadingIcon = { SearchIcon() },
                                     trailingIcon = {
                                         IconButton(onClick = {

--- a/app/src/main/java/helium314/keyboard/keyboard/emoji/SupportedEmojis.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/emoji/SupportedEmojis.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Paint
 import android.os.Build
 import androidx.core.content.edit
+import helium314.keyboard.keyboard.KeyboardTypeface
 import helium314.keyboard.latin.settings.Settings
 import helium314.keyboard.latin.utils.prefs
 
@@ -26,7 +27,7 @@ object SupportedEmojis {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return
         if (context.prefs().contains(Settings.PREF_EMOJI_MAX_SDK)) return
         val paint = Paint()
-        (Settings.getInstance().customEmojiTypeface ?: Settings.getInstance().customTypeface)
+        (KeyboardTypeface.emojiTypeface() ?: KeyboardTypeface.customTypeface())
             ?.let { paint.setTypeface(it) }
         val maxApi = context.assets.open("emoji/minApi.txt").reader().readLines().maxOf {
             val s = it.split(" ")

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/GestureFloatingTextDrawingPreview.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/GestureFloatingTextDrawingPreview.java
@@ -16,6 +16,7 @@ import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 
+import helium314.keyboard.keyboard.KeyboardTypeface;
 import helium314.keyboard.keyboard.PointerTracker;
 import helium314.keyboard.latin.R;
 import helium314.keyboard.latin.SuggestedWords;
@@ -72,7 +73,7 @@ public class GestureFloatingTextDrawingPreview extends AbstractDrawingPreview {
             mPaint.setAntiAlias(true);
             mPaint.setTextAlign(Align.CENTER);
             mPaint.setTextSize(mGesturePreviewTextSize);
-            mPaint.setTypeface(Settings.getInstance().getCustomTypeface());
+            mPaint.setTypeface(KeyboardTypeface.customTypeface());
             mPaint.setColor(mGesturePreviewTextColor);
             return mPaint;
         }

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/KeyPreviewView.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/KeyPreviewView.java
@@ -8,7 +8,6 @@ package helium314.keyboard.keyboard.internal;
 
 import android.content.Context;
 import android.graphics.Rect;
-import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.text.TextPaint;
 import android.text.TextUtils;
@@ -18,6 +17,7 @@ import android.view.Gravity;
 import android.widget.TextView;
 
 import helium314.keyboard.keyboard.Key;
+import helium314.keyboard.keyboard.KeyboardTypeface;
 import helium314.keyboard.latin.R;
 import helium314.keyboard.latin.common.StringUtilsKt;
 import helium314.keyboard.latin.settings.Settings;
@@ -33,7 +33,6 @@ public class KeyPreviewView extends TextView {
 
     private final Rect mBackgroundPadding = new Rect();
     private static final HashSet<String> sNoScaleXTextSet = new HashSet<>();
-    private final Typeface mTypeface;
 
     public KeyPreviewView(final Context context, final AttributeSet attrs) {
         this(context, attrs, 0);
@@ -42,7 +41,6 @@ public class KeyPreviewView extends TextView {
     public KeyPreviewView(final Context context, final AttributeSet attrs, final int defStyleAttr) {
         super(context, attrs, defStyleAttr);
         setGravity(Gravity.CENTER);
-        mTypeface = Settings.getInstance().getCustomTypeface();
     }
 
     public void setPreviewVisual(final Key key, final KeyboardIconsSet iconsSet, final KeyDrawParams drawParams) {
@@ -57,7 +55,7 @@ public class KeyPreviewView extends TextView {
         setTextColor(drawParams.mPreviewTextColor);
         setTextSize(TypedValue.COMPLEX_UNIT_PX, key.selectPreviewTextSize(drawParams)
                 * Settings.getValues().mFontSizeMultiplier);
-        setTypeface(mTypeface == null ? key.selectPreviewTypeface(drawParams) : mTypeface);
+        KeyboardTypeface.applyToTextView(this, key.getPreviewLabel(), key.selectPreviewTypeface(drawParams));
         // TODO Should take care of temporaryShiftLabel here.
         setTextAndScaleX(key.getPreviewLabel());
     }

--- a/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
+++ b/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
@@ -11,6 +11,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import androidx.core.view.isGone
+import helium314.keyboard.keyboard.KeyboardTypeface
 import helium314.keyboard.compat.ClipboardManagerCompat
 import helium314.keyboard.event.HapticEvent
 import helium314.keyboard.keyboard.internal.keyboard_parser.floris.KeyCode
@@ -128,7 +129,7 @@ class ClipboardHistoryManager(
         // create the view
         val binding = ClipboardSuggestionBinding.inflate(LayoutInflater.from(latinIME), parent, false)
         val textView = binding.clipboardSuggestionText
-        latinIME.mSettings.getCustomTypeface()?.let { textView.typeface = it }
+        KeyboardTypeface.applyToTextView(textView)
         textView.text = (if (isClipSensitive(inputType)) "*".repeat(content.length) else content)
             .take(200) // truncate displayed text for performance reasons
         val clipIcon = latinIME.mKeyboardSwitcher.keyboard.mIconsSet.getIconDrawable(ToolbarKey.PASTE.name.lowercase())

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -13,7 +13,6 @@ import android.content.pm.ApplicationInfo;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.BitmapFactory;
-import android.graphics.Typeface;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.view.ContextThemeWrapper;
@@ -201,10 +200,6 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
 
     // static cache for background images to avoid potentially slow reload on every settings reload
     private final static Drawable[] sCachedBackgroundImages = new Drawable[4];
-    private static Typeface sCachedTypeface;
-    private static boolean sCustomTypefaceLoaded; // to avoid repeatedly checking custom typeface file when there is no custom typeface
-    private static Typeface sCachedEmojiTypeface;
-    private static boolean sCustomEmojiTypefaceLoaded;
 
     private static final Settings sInstance = new Settings();
 
@@ -578,32 +573,4 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
         return mPrefs.getBoolean(PREF_SAVE_SUBTYPE_PER_APP, Defaults.PREF_SAVE_SUBTYPE_PER_APP);
     }
 
-    @Nullable
-    public Typeface getCustomTypeface() {
-        if (!sCustomTypefaceLoaded) {
-            try {
-                sCachedTypeface = Typeface.createFromFile(getCustomFontFile(mContext));
-            } catch (Exception ignored) { }
-        }
-        sCustomTypefaceLoaded = true;
-        return sCachedTypeface;
-    }
-
-    @Nullable
-    public Typeface getCustomEmojiTypeface() {
-        if (!sCustomEmojiTypefaceLoaded) {
-            try {
-                sCachedEmojiTypeface = Typeface.createFromFile(getCustomEmojiFontFile(mContext));
-            } catch (Exception ignored) { }
-        }
-        sCustomEmojiTypefaceLoaded = true;
-        return sCachedEmojiTypeface;
-    }
-
-    public static void clearCachedTypeface() {
-        sCachedTypeface = null;
-        sCustomTypefaceLoaded = false;
-        sCachedEmojiTypeface = null;
-        sCustomEmojiTypefaceLoaded = false;
-    }
 }

--- a/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripLayoutHelper.java
+++ b/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripLayoutHelper.java
@@ -37,13 +37,13 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import helium314.keyboard.accessibility.AccessibilityUtils;
+import helium314.keyboard.keyboard.KeyboardTypeface;
 import helium314.keyboard.latin.PunctuationSuggestions;
 import helium314.keyboard.latin.R;
 import helium314.keyboard.latin.SuggestedWords;
 import helium314.keyboard.latin.SuggestedWords.SuggestedWordInfo;
 import helium314.keyboard.latin.common.ColorType;
 import helium314.keyboard.latin.common.Colors;
-import helium314.keyboard.latin.common.StringUtilsKt;
 import helium314.keyboard.latin.settings.Settings;
 import helium314.keyboard.latin.settings.SettingsValues;
 import helium314.keyboard.latin.utils.ResourceUtils;
@@ -469,7 +469,6 @@ final class SuggestionStripLayoutHelper {
         }
         int count = 0;
         int indexInSuggestedWords;
-        final Typeface emojiTypeface = Settings.getInstance().getCustomEmojiTypeface();
         for (indexInSuggestedWords = 0; indexInSuggestedWords < suggestedWords.size()
                 && count < maxSuggestionInStrip; indexInSuggestedWords++) {
             final int positionInStrip =
@@ -483,10 +482,7 @@ final class SuggestionStripLayoutHelper {
             wordView.setTag(indexInSuggestedWords);
             wordView.setText(getStyledSuggestedWord(suggestedWords, indexInSuggestedWords));
             wordView.setTextColor(getSuggestionTextColor(suggestedWords, indexInSuggestedWords));
-
-            if (emojiTypeface != null && StringUtilsKt.isEmoji(wordView.getText()))
-                wordView.setTypeface(emojiTypeface);
-            else wordView.setTypeface(Typeface.DEFAULT); // todo: maybe use user-provided typeface here?
+            KeyboardTypeface.applyToTextView(wordView);
             if (SuggestionStripView.DEBUG_SUGGESTIONS) {
                 mDebugInfoViews.get(positionInStrip).setText(suggestedWords.getDebugString(indexInSuggestedWords));
             }
@@ -514,6 +510,7 @@ final class SuggestionStripLayoutHelper {
             wordView.setTextScaleX(1.0f);
             wordView.setCompoundDrawables(null, null, null, null);
             wordView.setTextColor(mColorAutoCorrect);
+            KeyboardTypeface.applyToTextView(wordView);
             stripView.addView(wordView);
             setLayoutWeight(wordView, 1.0f, mSuggestionsStripHeight);
         }

--- a/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.kt
+++ b/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.kt
@@ -94,14 +94,11 @@ class SuggestionStripView(context: Context, attrs: AttributeSet?, defStyle: Int)
 
         val colors = Settings.getValues().mColors
         colors.setBackground(this, ColorType.STRIP_BACKGROUND)
-        val customTypeface = Settings.getInstance().customTypeface
         repeat(SuggestedWords.MAX_SUGGESTIONS) {
             val word = TextView(context, null, R.attr.suggestionWordStyle)
             word.contentDescription = resources.getString(R.string.spoken_empty_suggestion)
             word.setOnClickListener(this)
             word.setOnLongClickListener(this)
-            if (customTypeface != null)
-                word.typeface = customTypeface
             colors.setBackground(word, ColorType.STRIP_BACKGROUND)
             wordViews.add(word)
             val divider = inflater.inflate(R.layout.suggestion_divider, null)

--- a/app/src/main/java/helium314/keyboard/settings/preferences/CustomFontPreference.kt
+++ b/app/src/main/java/helium314/keyboard/settings/preferences/CustomFontPreference.kt
@@ -14,10 +14,10 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import helium314.keyboard.keyboard.KeyboardTypeface
 import helium314.keyboard.keyboard.KeyboardSwitcher
 import helium314.keyboard.latin.R
 import helium314.keyboard.latin.common.FileUtils
-import helium314.keyboard.latin.settings.Settings
 import helium314.keyboard.latin.utils.DeviceProtectedUtils
 import helium314.keyboard.settings.Setting
 import helium314.keyboard.settings.dialogs.ConfirmationDialog
@@ -38,7 +38,7 @@ fun CustomFontPreference(setting: Setting, fontFile: File, title: Int) {
             Typeface.createFromFile(tempFile)
             fontFile.delete()
             tempFile.renameTo(fontFile)
-            Settings.clearCachedTypeface()
+            KeyboardTypeface.clearCache()
             KeyboardSwitcher.getInstance().setThemeNeedsReload()
         } catch (_: Exception) {
             showErrorDialog = true
@@ -63,7 +63,7 @@ fun CustomFontPreference(setting: Setting, fontFile: File, title: Int) {
             onNeutral = {
                 showDialog = false
                 fontFile.delete()
-                Settings.clearCachedTypeface()
+                KeyboardTypeface.clearCache()
                 KeyboardSwitcher.getInstance().setThemeNeedsReload()
             },
             neutralButtonText = stringResource(R.string.delete),


### PR DESCRIPTION
This PR fixes #2314 and #2368 by consolidating the typeface and emoji font resolution into a single helper class, KeyboardTypeface.kt, and makes sure that custom UI and emoji fonts load consistently across all keyboard components (if I didn't miss anything). This doesn't fix any of the font issues with text getting cut off in the suggestions bar or overlapping emoticons, like in #1837, but I'll try to make time to fix it later.

I am not an Android developer, and I have used AI extensively to help structure this refactor and ensure the Kotlin/Java interop was correct. However, I have manually tweaked the AI-generated logic and compiled and ran the app multiple times using ./gradlew assembleDebug on a Windows environment to verify that both the standard keyboard views and the Compose-based search activities render fonts as expected.