### PR TITLE
Don't flip parentheses on RTL languages

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/internal/keyboard_parser/floris/KeyLabel.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/keyboard_parser/floris/KeyLabel.kt
@@ -66,7 +66,7 @@ object KeyLabel {
     }
 
     fun String.rtlLabel(params: KeyboardParams): String {
-        if (!params.mId.mSubtype.isRtlSubtype || params.mId.isNumberLayout) return this
+        if (true) return this
         return when (this) {
             "{" -> "{|}"
             "}" -> "}|{"


### PR DESCRIPTION
Samsung phones seem to currently not require the flipping.

This is a draft meant to test this approach. If it works, we should probably add a setting or somehow detect automatically which phones need the flip.

Will fix #2232, fix #2333.
